### PR TITLE
Export link properties as JSON

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/Link.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/Link.kt
@@ -52,7 +52,7 @@ class Link : JSONable, Serializable {
         json.putOpt("href", href)
         if (rel.isNotEmpty())
             json.put("rel", getStringArray(rel))
-        json.putOpt("properties", properties)
+        json.putOpt("properties", properties.getJSON())
         if (height != 0)
             json.putOpt("height", height)
         if (width != 0)


### PR DESCRIPTION
cf https://github.com/readium/r2-streamer-kotlin/issues/23

The properties object is not exported as JSON.