### PR TITLE
Print nested childrens of TOC in manifest json

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/Link.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/Link.kt
@@ -55,12 +55,14 @@ class Link : JSONable, Serializable {
         json.putOpt("href", href)
         if (rel.isNotEmpty())
             json.put("rel", getStringArray(rel))
-        json.putOpt("properties", properties)
+        tryPut(json, properties, "properties")
         if (height != 0)
             json.putOpt("height", height)
         if (width != 0)
             json.putOpt("width", width)
         json.putOpt("duration", duration)
+        if (children.isNotEmpty())
+            json.put("children", getJSONArray(children))
         return json
     }
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/Publication.kt
@@ -44,6 +44,13 @@ fun tryPut(obj: JSONObject, list: List<JSONable>, tag: String) {
         obj.putOpt(tag, getJSONArray(list))
 }
 
+// Try to put class which implements JSONable only if not empty
+fun tryPut(jsonObject: JSONObject, jsonable: JSONable, tag: String) {
+    val tempJsonObject = jsonable.getJSON()
+    if (tempJsonObject.length() != 0)
+        jsonObject.put(tag, tempJsonObject)
+}
+
 class TocElement(val link: Link, val children: List<TocElement>) : JSONable {
 
     override fun getJSON(): JSONObject {


### PR DESCRIPTION
Hi guys!

I am developer on [FolioReader-Android][1] EPUB SDK and we have started migrating from r2-streamer-java to r2-streamer-kotlin

I see manifest JSON representation of `Publication` has nested `Link` missing.
Nested `Link` are observerd in TOC creation.

We currently are more being dependent on manifest JSON from URL than in memory object.
It would be helpful if you could accept this PR.

Also I have done corrrection in `Properties` JSON representation.

[1]: https://github.com/FolioReader/FolioReader-Android