### PR TITLE
Add MediaType API

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/format/MediaType.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/format/MediaType.kt
@@ -1,0 +1,297 @@
+/*
+ * Module: r2-shared-kotlin
+ * Developers: Mickaël Menu
+ *
+ * Copyright (c) 2020. Readium Foundation. All rights reserved.
+ * Use of this source code is governed by a BSD-style license which is detailed in the
+ * LICENSE file present in the project repository where this source code is maintained.
+ */
+
+package org.readium.r2.shared.format
+
+import org.readium.r2.shared.publication.Link
+import java.lang.IllegalArgumentException
+import java.nio.charset.Charset
+import java.util.*
+
+/**
+ * Represents a string media type.
+ *
+ * [MediaType] handles:
+ *  - components parsing – eg. type, subtype and parameters,
+ *  - media types comparison.
+ *
+ * Comparing media types is more complicated than it looks, since they can contain parameters,
+ * such as `charset=utf-8`. We can't ignore them because some formats use parameters in their
+ * media type, for example `application/atom+xml;profile=opds-catalog` for an OPDS 1 catalog.
+ *
+ * Specification: https://tools.ietf.org/html/rfc6838
+ *
+ * @param string String representation for this media type.
+ */
+class MediaType private constructor(string: String) {
+
+    /** The type component, e.g. `application` in `application/epub+zip`. */
+    val type: String
+
+    /** The subtype component, e.g. `epub+zip` in `application/epub+zip`. */
+    val subtype: String
+
+    /** The parameters in the media type, such as `charset=utf-8`. */
+    val parameters: Map<String, String>
+
+    init {
+        if (string.isEmpty()) {
+            throw IllegalArgumentException("Invalid media type: $string")
+        }
+
+        // Grammar: https://tools.ietf.org/html/rfc2045#section-5.1
+        val components = string.split(";")
+            .map { it.trim() }
+        val types = components[0].split("/")
+        if (types.size != 2) {
+            throw IllegalArgumentException("Invalid media type: $string")
+        }
+
+        // > Both top-level type and subtype names are case-insensitive.
+        this.type = types[0].toLowerCase(Locale.ROOT)
+        this.subtype = types[1].toLowerCase(Locale.ROOT)
+
+        // > Parameter names are case-insensitive and no meaning is attached to the order in which
+        // > they appear.
+        val parameters = components.drop(1)
+            .map { it.split("=") }
+            .filter { it.size == 2 }
+            .associate { Pair(it[0].toLowerCase(Locale.ROOT), it[1]) }
+            .toMutableMap()
+
+        // For now, we only support case-insensitive `charset`.
+        //
+        // > Parameter values might or might not be case-sensitive, depending on the semantics of
+        // > the parameter name.
+        // > https://tools.ietf.org/html/rfc2616#section-3.7
+        //
+        // > The character set names may be up to 40 characters taken from the printable characters
+        // > of US-ASCII.  However, no distinction is made between use of upper and lower case
+        // > letters.
+        // > https://www.iana.org/assignments/character-sets/character-sets.xhtml
+        parameters["charset"]?.let {
+            parameters["charset"] = it.toUpperCase(Locale.ROOT)
+        }
+
+        this.parameters = parameters
+    }
+
+    /**
+     * Structured syntax suffix, e.g. `+zip` in `application/epub+zip`.
+     *
+     * Gives a hint on the underlying structure of this media type.
+     * See. https://tools.ietf.org/html/rfc6838#section-4.2.8
+     */
+    val structuredSyntaxSuffix: String? get() {
+        val parts = subtype.split("+")
+        return if (parts.size > 1) "+${parts.last()}" else null
+    }
+
+    /**
+     * Encoding as declared in the `charset` parameter, if there's any.
+     */
+    val charset: Charset? get() =
+        parameters["charset"]?.let { Charset.forName(it) }
+
+    /** The string representation of this media type. */
+    override fun toString(): String {
+        var params = parameters.map { "${it.key}=${it.value}" }
+            .sorted()
+            .joinToString(separator = ";")
+        if (params.isNotEmpty()) {
+            params = ";$params"
+        }
+        return "$type/$subtype$params"
+    }
+
+    /**
+     * Returns whether two media types are equal, checking the type, subtype and parameters.
+     * Parameters order is ignored.
+     */
+    override fun equals(other: Any?): Boolean {
+        @Suppress("NAME_SHADOWING")
+        val other = other as? MediaType
+            ?: return false
+
+        return type == other.type && subtype == other.subtype && parameters == other.parameters
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + subtype.hashCode()
+        result = 31 * result + parameters.hashCode()
+        return result
+    }
+
+    /**
+     * Returns whether the given [other] media type is included in this media type.
+     *
+     * For example, `text/html` contains `text/html;charset=utf-8`.
+     *
+     * - [other] must match the parameters in the [parameters] property, but extra parameters
+     *    are ignored.
+     * - Order of parameters is ignored.
+     * - Wildcards are supported, meaning that `image/*` contains `image/png` and `*/*` contains
+     *   everything.
+     */
+    fun contains(other: MediaType?): Boolean {
+        if (other == null || (type != "*" && type != other.type) || (subtype != "*" && subtype != other.subtype)) {
+            return false
+        }
+        val paramsSet = parameters.map { "${it.key}=${it.value}" }.toSet()
+        val otherParamsSet = other.parameters.map { "${it.key}=${it.value}" }.toSet()
+        return otherParamsSet.containsAll(paramsSet)
+    }
+
+    /**
+     * Returns whether the given [other] media type is included in this media type.
+     */
+    fun contains(other: String?): Boolean {
+        val mediaType = other?.let { parse(it) }
+            ?: return false
+
+        return contains(mediaType)
+    }
+
+    /**
+     * Returns whether this media type is included in the provided [other] media type.
+     *
+     * For example, `text/html;charset=utf-8` is part of `text/html`.
+     */
+    fun isPartOf(other: MediaType?): Boolean =
+        other?.contains(this) ?: false
+
+    /**
+     * Returns whether this media type is included in the provided [other] media type.
+     */
+    fun isPartOf(other: String?): Boolean =
+        other?.let { parse(it) }?.contains(this) ?: false
+
+    /** Returns whether this media type is structured as a ZIP archive. */
+    val isZip: Boolean get() {
+        return isPartOf(ZIP)
+            || isPartOf(LCP_PROTECTED_AUDIOBOOK)
+            || isPartOf(LCP_PROTECTED_PDF)
+            || structuredSyntaxSuffix == "+zip"
+    }
+
+    /** Returns whether this media type is structured as a JSON file. */
+    val isJson: Boolean get() {
+        return isPartOf(JSON)
+            || structuredSyntaxSuffix == "+json"
+    }
+
+    /** Returns whether this media type is of an OPDS feed. */
+    val isOpds: Boolean get() {
+        return isPartOf(OPDS1)
+            || isPartOf(OPDS1_ENTRY)
+            || isPartOf(OPDS2)
+            || isPartOf(OPDS2_PUBLICATION)
+    }
+
+    /** Returns whether this media type is of an HTML document. */
+    val isHtml: Boolean get() {
+        return isPartOf(HTML)
+            || isPartOf(XHTML)
+    }
+
+    /** Returns whether this media type is of a bitmap image, so excluding vectorial formats. */
+    val isBitmap: Boolean get() {
+        return isPartOf(BMP)
+            || isPartOf(GIF)
+            || isPartOf(JPEG)
+            || isPartOf(PNG)
+            || isPartOf(TIFF)
+            || isPartOf(WEBP)
+    }
+
+    /** Returns whether this media type is of a Readium Web Publication Manifest. */
+    val isRwpm: Boolean get() {
+        return isPartOf(AUDIOBOOK_MANIFEST)
+            || isPartOf(DIVINA_MANIFEST)
+            || isPartOf(WEBPUB_MANIFEST)
+    }
+
+    companion object {
+
+        /**
+         * Creates a [MediaType] from its string representation.
+         */
+        fun parse(string: String): MediaType? =
+            try {
+                MediaType(string)
+            } catch (e: Exception) {
+                null
+            }
+
+        // Known Media Types
+
+        val AAC = MediaType("audio/aac")
+        val ACSM = MediaType("application/vnd.adobe.adept+xml")
+        val AIFF = MediaType("audio/aiff")
+        val AUDIOBOOK = MediaType("application/audiobook+zip")
+        val AUDIOBOOK_MANIFEST = MediaType("application/audiobook+json")
+        val AVI = MediaType("video/x-msvideo")
+        val BINARY = MediaType("application/octet-stream")
+        val BMP = MediaType("image/bmp")
+        val CBZ = MediaType("application/vnd.comicbook+zip")
+        val CSS = MediaType("text/css")
+        val DIVINA = MediaType("application/divina+zip")
+        val DIVINA_MANIFEST = MediaType("application/divina+json")
+        val EPUB = MediaType("application/epub+zip")
+        val GIF = MediaType("image/gif")
+        val GZ = MediaType("application/gzip")
+        val JAVASCRIPT = MediaType("text/javascript")
+        val JPEG = MediaType("image/jpeg")
+        val HTML = MediaType("text/html")
+        val OPDS1 = MediaType("application/atom+xml;profile=opds-catalog")
+        val OPDS1_ENTRY = MediaType("application/atom+xml;type=entry;profile=opds-catalog")
+        val OPDS2 = MediaType("application/opds+json")
+        val OPDS2_PUBLICATION = MediaType("application/opds-publication+json")
+        val JSON = MediaType("application/json")
+        val LCP_PROTECTED_AUDIOBOOK = MediaType("application/audiobook+lcp")
+        val LCP_PROTECTED_PDF = MediaType("application/pdf+lcp")
+        val LCP_LICENSE_DOCUMENT = MediaType("application/vnd.readium.lcp.license.v1.0+json")
+        val LCP_STATUS_DOCUMENT = MediaType("application/vnd.readium.license.status.v1.0+json")
+        val LPF = MediaType("application/lpf+zip")
+        val MP3 = MediaType("audio/mpeg")
+        val MPEG = MediaType("video/mpeg")
+        val NCX = MediaType("application/x-dtbncx+xml")
+        val OGG = MediaType("audio/ogg")
+        val OGV = MediaType("video/ogg")
+        val OPUS = MediaType("audio/opus")
+        val OTF = MediaType("font/otf")
+        val PDF = MediaType("application/pdf")
+        val PNG = MediaType("image/png")
+        val SMIL = MediaType("application/smil+xml")
+        val SVG = MediaType("image/svg+xml")
+        val TEXT = MediaType("text/plain")
+        val TIFF = MediaType("image/tiff")
+        val TTF = MediaType("font/ttf")
+        val W3C_WPUB_MANIFEST = MediaType("application/x.readium.w3c.wpub+json")  // non-existent
+        val WAV = MediaType("audio/wav")
+        val WEBM_AUDIO = MediaType("audio/webm")
+        val WEBM_VIDEO = MediaType("video/webm")
+        val WEBP = MediaType("image/webp")
+        val WEBPUB = MediaType("application/webpub+zip")
+        val WEBPUB_MANIFEST = MediaType("application/webpub+json")
+        val WOFF = MediaType("font/woff")
+        val WOFF2 = MediaType("font/woff2")
+        val XHTML = MediaType("application/xhtml+xml")
+        val XML = MediaType("application/xml")
+        val ZAB = MediaType("application/x.readium.zab+zip")  // non-existent
+        val ZIP = MediaType("application/zip")
+
+    }
+
+}
+
+/** Media type of the linked resource. */
+val Link.mediaType: MediaType? get() =
+    type?.let { MediaType.parse(it) }

--- a/r2-shared/src/main/java/org/readium/r2/shared/format/MediaType.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/format/MediaType.kt
@@ -217,6 +217,10 @@ class MediaType private constructor(string: String) {
             || matches(WEBP)
     }
 
+    /** Returns whether this media type is of an audio clip. */
+    val isAudio: Boolean get() =
+        type == "audio"
+
     /** Returns whether this media type is of a Readium Web Publication Manifest. */
     val isRwpm: Boolean get() {
         return matches(AUDIOBOOK_MANIFEST)

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -23,6 +23,7 @@ import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.extensions.optStringsFromArrayOrSingle
 import org.readium.r2.shared.extensions.putIfNotEmpty
 import org.readium.r2.shared.extensions.removeLastComponent
+import org.readium.r2.shared.format.MediaType
 import org.readium.r2.shared.publication.epub.listOfAudioClips
 import org.readium.r2.shared.publication.epub.listOfVideoClips
 import org.readium.r2.shared.toJSON
@@ -174,7 +175,7 @@ data class Publication(
     fun setSelfLink(href: String) {
         links = links.toMutableList().apply {
             removeAll { it.rels.contains("self") }
-            add(Link(href = href, type = "application/webpub+json", rels = setOf("self")))
+            add(Link(href = href, type = MediaType.WEBPUB_MANIFEST.toString(), rels = setOf("self")))
         }
     }
 

--- a/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
@@ -289,6 +289,13 @@ class MediaTypeTest {
     }
 
     @Test
+    fun `is audio`() {
+        assertFalse(MediaType.parse("text/html")!!.isAudio)
+        assertTrue(MediaType.parse("audio/unknown")!!.isAudio)
+        assertTrue(MediaType.parse("audio/mpeg;param=value")!!.isAudio)
+    }
+
+    @Test
     fun `is RWPM`() {
         assertFalse(MediaType.parse("text/html")!!.isRwpm)
         assertTrue(MediaType.parse("application/audiobook+json")!!.isRwpm)

--- a/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
@@ -1,0 +1,300 @@
+/*
+ * Module: r2-shared-kotlin
+ * Developers: Mickaël Menu
+ *
+ * Copyright (c) 2020. Readium Foundation. All rights reserved.
+ * Use of this source code is governed by a BSD-style license which is detailed in the
+ * LICENSE file present in the project repository where this source code is maintained.
+ */
+
+package org.readium.r2.shared.format
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class MediaTypeTest {
+
+    @Test
+    fun `returns null for invalid types`() {
+        assertNull(MediaType.parse("application"))
+        assertNull(MediaType.parse("application/atom+xml/extra"))
+    }
+
+    @Test
+    fun `to string`() {
+        assertEquals(
+            "application/atom+xml;profile=opds-catalog",
+            MediaType.parse("application/atom+xml;profile=opds-catalog")?.toString()
+        )
+    }
+
+    @Test
+    fun `to string is normalized`() {
+        assertEquals(
+            "application/atom+xml;a=0;profile=OPDS-CATALOG",
+            MediaType.parse("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG   ;   a=0")?.toString()
+        )
+        // Parameters are sorted by name
+        assertEquals(
+            "application/atom+xml;a=0;b=1",
+            MediaType.parse("application/atom+xml;a=0;b=1")?.toString()
+        )
+        assertEquals(
+            "application/atom+xml;a=0;b=1",
+            MediaType.parse("application/atom+xml;b=1;a=0")?.toString()
+        )
+    }
+
+    @Test
+    fun `get type`() {
+        assertEquals(
+            "application",
+            MediaType.parse("application/atom+xml;profile=opds-catalog")?.type
+        )
+        assertEquals("*", MediaType.parse("*/jpeg")?.type)
+    }
+
+    @Test
+    fun `get subtype`() {
+        assertEquals(
+            "atom+xml",
+            MediaType.parse("application/atom+xml;profile=opds-catalog")?.subtype
+        )
+        assertEquals("*", MediaType.parse("image/*")?.subtype)
+    }
+
+    @Test
+    fun `get parameters`() {
+        assertEquals(
+            mapOf(
+                "type" to "entry",
+                "profile" to "opds-catalog"
+            ),
+            MediaType.parse("application/atom+xml;type=entry;profile=opds-catalog")?.parameters
+        )
+    }
+
+    @Test
+    fun `get empty parameters`() {
+        assertTrue(MediaType.parse("application/atom+xml")!!.parameters.isEmpty())
+    }
+
+    @Test
+    fun `get parameters with whitespaces`() {
+        assertEquals(
+            mapOf(
+                "type" to "entry",
+                "profile" to "opds-catalog"
+            ),
+            MediaType.parse("application/atom+xml    ;    type=entry   ;    profile=opds-catalog   ")?.parameters
+        )
+    }
+
+    @Test
+    fun `get structured syntax suffix`() {
+        assertNull(MediaType.parse("foo/bar")?.structuredSyntaxSuffix)
+        assertNull(MediaType.parse("application/zip")?.structuredSyntaxSuffix)
+        assertEquals("+zip", MediaType.parse("application/epub+zip")?.structuredSyntaxSuffix)
+        assertEquals("+zip", MediaType.parse("foo/bar+json+zip")?.structuredSyntaxSuffix)
+    }
+
+    @Test
+    fun `get charset`() {
+        assertNull(MediaType.parse("text/html")?.charset)
+        assertEquals(Charsets.UTF_8, MediaType.parse("text/html;charset=utf-8")?.charset)
+        assertEquals(Charsets.UTF_16, MediaType.parse("text/html;charset=utf-16")?.charset)
+    }
+
+    @Test
+    fun `type, subtype and parameter names are lowercased`() {
+        val mediaType = MediaType.parse("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG")
+        assertEquals("application", mediaType?.type)
+        assertEquals("atom+xml", mediaType?.subtype)
+        assertEquals(mapOf("profile" to "OPDS-CATALOG"), mediaType?.parameters)
+    }
+
+    @Test
+    fun `charset value is uppercased`() {
+        assertEquals("UTF-8", MediaType.parse("text/html;charset=utf-8")?.parameters?.get("charset"))
+    }
+
+    @Test
+    fun equality() {
+        assertEquals(MediaType.parse("application/atom+xml")!!, MediaType.parse("application/atom+xml")!!)
+        assertEquals(MediaType.parse("application/atom+xml;profile=opds-catalog")!!, MediaType.parse("application/atom+xml;profile=opds-catalog")!!)
+        assertNotEquals(MediaType.parse("application/atom+xml")!!, MediaType.parse("application/atom")!!)
+        assertNotEquals(MediaType.parse("application/atom+xml")!!, MediaType.parse("text/atom+xml")!!)
+        assertNotEquals(MediaType.parse("application/atom+xml;profile=opds-catalog")!!, MediaType.parse("application/atom+xml")!!)
+    }
+
+    @Test
+    fun `equality ignores case of type, subtype and parameter names`() {
+        assertEquals(
+            MediaType.parse("application/atom+xml;profile=opds-catalog")!!,
+            MediaType.parse("APPLICATION/ATOM+XML;PROFILE=opds-catalog")!!
+        )
+        assertNotEquals(
+            MediaType.parse("application/atom+xml;profile=opds-catalog")!!,
+            MediaType.parse("APPLICATION/ATOM+XML;PROFILE=OPDS-CATALOG")!!
+        )
+    }
+
+    @Test
+    fun `equality ignores parameters order`() {
+        assertEquals(
+            MediaType.parse("application/atom+xml;type=entry;profile=opds-catalog")!!,
+            MediaType.parse("application/atom+xml;profile=opds-catalog;type=entry")!!
+        )
+    }
+
+    @Test
+    fun `equality ignores charset case`() {
+        assertEquals(
+            MediaType.parse("application/atom+xml;charset=utf-8")!!,
+            MediaType.parse("application/atom+xml;charset=UTF-8")!!
+        )
+    }
+
+    @Test
+    fun `contains equal media type`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.contains(MediaType.parse("text/html;charset=utf-8")))
+    }
+
+    @Test
+    fun `contains must match parameters`() {
+        assertFalse(MediaType.parse("text/html;charset=utf-8")
+            !!.contains(MediaType.parse("text/html;charset=ascii")))
+        assertFalse(MediaType.parse("text/html;charset=utf-8")
+            !!.contains(MediaType.parse("text/html")))
+    }
+
+    @Test
+    fun `contains ignores parameters order`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8;type=entry")
+            !!.contains(MediaType.parse("text/html;type=entry;charset=utf-8")))
+    }
+
+    @Test
+    fun `contains ignore extra parameters`() {
+        assertTrue(MediaType.parse("text/html")
+            !!.contains(MediaType.parse("text/html;charset=utf-8")))
+    }
+
+    @Test
+    fun `contains supports wildcards`() {
+        assertTrue(MediaType.parse("*/*")
+            !!.contains(MediaType.parse("text/html;charset=utf-8")))
+        assertTrue(MediaType.parse("text/*")
+            !!.contains(MediaType.parse("text/html;charset=utf-8")))
+        assertFalse(MediaType.parse("text/*")
+            !!.contains(MediaType.parse("application/zip")))
+    }
+
+    @Test
+    fun `contains from string`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.contains("text/html;charset=utf-8"))
+    }
+
+    @Test
+    fun `is part of equal media type`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
+    }
+
+    @Test
+    fun `is part of must match parameters`() {
+        assertFalse(MediaType.parse("text/html;charset=ascii")
+            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
+        assertFalse(MediaType.parse("text/html")
+            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
+    }
+
+    @Test
+    fun `is part of ignores parameters order`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8;type=entry")
+            !!.isPartOf(MediaType.parse("text/html;type=entry;charset=utf-8")))
+    }
+
+    @Test
+    fun `is part of ignores extra parameters`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.isPartOf(MediaType.parse("text/html")))
+    }
+
+    @Test
+    fun `is part of supports wildcards`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.isPartOf(MediaType.parse("*/*")))
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.isPartOf(MediaType.parse("text/*")))
+        assertFalse(MediaType.parse("application/zip")
+            !!.isPartOf(MediaType.parse("text/*")))
+    }
+
+    @Test
+    fun `is part of from string`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")
+            !!.isPartOf("text/html;charset=utf-8"))
+    }
+
+    @Test
+    fun `is ZIP`() {
+        assertFalse(MediaType.parse("text/plain")!!.isZip)
+        assertTrue(MediaType.parse("application/zip")!!.isZip)
+        assertTrue(MediaType.parse("application/zip;charset=utf-8")!!.isZip)
+        assertTrue(MediaType.parse("application/epub+zip")!!.isZip)
+        // These media types must be explicitely matched since they don't have any ZIP hint
+        assertTrue(MediaType.parse("application/audiobook+lcp")!!.isZip)
+        assertTrue(MediaType.parse("application/pdf+lcp")!!.isZip)
+    }
+
+    @Test
+    fun `is JSON`() {
+        assertFalse(MediaType.parse("text/plain")!!.isJson)
+        assertTrue(MediaType.parse("application/json")!!.isJson)
+        assertTrue(MediaType.parse("application/json;charset=utf-8")!!.isJson)
+        assertTrue(MediaType.parse("application/opds+json")!!.isJson)
+    }
+
+    @Test
+    fun `is OPDS`() {
+        assertFalse(MediaType.parse("text/html")!!.isOpds)
+        assertTrue(MediaType.parse("application/atom+xml;profile=opds-catalog")!!.isOpds)
+        assertTrue(MediaType.parse("application/atom+xml;type=entry;profile=opds-catalog")!!.isOpds)
+        assertTrue(MediaType.parse("application/opds+json")!!.isOpds)
+        assertTrue(MediaType.parse("application/opds-publication+json")!!.isOpds)
+        assertTrue(MediaType.parse("application/opds+json;charset=utf-8")!!.isOpds)
+    }
+
+    @Test
+    fun `is HTML`() {
+        assertFalse(MediaType.parse("application/opds+json")!!.isHtml)
+        assertTrue(MediaType.parse("text/html")!!.isHtml)
+        assertTrue(MediaType.parse("application/xhtml+xml")!!.isHtml)
+        assertTrue(MediaType.parse("text/html;charset=utf-8")!!.isHtml)
+    }
+
+    @Test
+    fun `is bitmap`() {
+        assertFalse(MediaType.parse("text/html")!!.isBitmap)
+        assertTrue(MediaType.parse("image/bmp")!!.isBitmap)
+        assertTrue(MediaType.parse("image/gif")!!.isBitmap)
+        assertTrue(MediaType.parse("image/jpeg")!!.isBitmap)
+        assertTrue(MediaType.parse("image/png")!!.isBitmap)
+        assertTrue(MediaType.parse("image/tiff")!!.isBitmap)
+        assertTrue(MediaType.parse("image/tiff")!!.isBitmap)
+        assertTrue(MediaType.parse("image/tiff;charset=utf-8")!!.isBitmap)
+    }
+
+    @Test
+    fun `is RWPM`() {
+        assertFalse(MediaType.parse("text/html")!!.isRwpm)
+        assertTrue(MediaType.parse("application/audiobook+json")!!.isRwpm)
+        assertTrue(MediaType.parse("application/divina+json")!!.isRwpm)
+        assertTrue(MediaType.parse("application/webpub+json")!!.isRwpm)
+        assertTrue(MediaType.parse("application/webpub+json;charset=utf-8")!!.isRwpm)
+    }
+
+}

--- a/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
@@ -245,7 +245,7 @@ class MediaTypeTest {
         assertTrue(MediaType.parse("application/zip")!!.isZip)
         assertTrue(MediaType.parse("application/zip;charset=utf-8")!!.isZip)
         assertTrue(MediaType.parse("application/epub+zip")!!.isZip)
-        // These media types must be explicitely matched since they don't have any ZIP hint
+        // These media types must be explicitly matched since they don't have any ZIP hint
         assertTrue(MediaType.parse("application/audiobook+lcp")!!.isZip)
         assertTrue(MediaType.parse("application/pdf+lcp")!!.isZip)
     }

--- a/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/format/MediaTypeTest.kt
@@ -198,45 +198,45 @@ class MediaTypeTest {
     }
 
     @Test
-    fun `is part of equal media type`() {
+    fun `matches equal media type`() {
         assertTrue(MediaType.parse("text/html;charset=utf-8")
-            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
+            !!.matches(MediaType.parse("text/html;charset=utf-8")))
     }
 
     @Test
-    fun `is part of must match parameters`() {
+    fun `matches must match parameters`() {
         assertFalse(MediaType.parse("text/html;charset=ascii")
-            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
-        assertFalse(MediaType.parse("text/html")
-            !!.isPartOf(MediaType.parse("text/html;charset=utf-8")))
+            !!.matches(MediaType.parse("text/html;charset=utf-8")))
     }
 
     @Test
-    fun `is part of ignores parameters order`() {
+    fun `matches ignores parameters order`() {
         assertTrue(MediaType.parse("text/html;charset=utf-8;type=entry")
-            !!.isPartOf(MediaType.parse("text/html;type=entry;charset=utf-8")))
+            !!.matches(MediaType.parse("text/html;type=entry;charset=utf-8")))
     }
 
     @Test
-    fun `is part of ignores extra parameters`() {
+    fun `matches ignores extra parameters`() {
         assertTrue(MediaType.parse("text/html;charset=utf-8")
-            !!.isPartOf(MediaType.parse("text/html")))
+            !!.matches(MediaType.parse("text/html;charset=utf-8;extra=param")))
+        assertTrue(MediaType.parse("text/html;charset=utf-8;extra=param")
+            !!.matches(MediaType.parse("text/html;charset=utf-8")))
     }
 
     @Test
-    fun `is part of supports wildcards`() {
-        assertTrue(MediaType.parse("text/html;charset=utf-8")
-            !!.isPartOf(MediaType.parse("*/*")))
-        assertTrue(MediaType.parse("text/html;charset=utf-8")
-            !!.isPartOf(MediaType.parse("text/*")))
-        assertFalse(MediaType.parse("application/zip")
-            !!.isPartOf(MediaType.parse("text/*")))
+    fun `matches supports wildcards`() {
+        assertTrue(MediaType.parse("text/html;charset=utf-8")!!.matches(MediaType.parse("*/*")))
+        assertTrue(MediaType.parse("text/html;charset=utf-8")!!.matches(MediaType.parse("text/*")))
+        assertFalse(MediaType.parse("application/zip")!!.matches(MediaType.parse("text/*")))
+        assertTrue(MediaType.parse("*/*")!!.matches(MediaType.parse("text/html;charset=utf-8")))
+        assertTrue(MediaType.parse("text/*")!!.matches(MediaType.parse("text/html;charset=utf-8")))
+        assertFalse(MediaType.parse("text/*")!!.matches(MediaType.parse("application/zip")))
     }
 
     @Test
-    fun `is part of from string`() {
+    fun `matches from string`() {
         assertTrue(MediaType.parse("text/html;charset=utf-8")
-            !!.isPartOf("text/html;charset=utf-8"))
+            !!.matches("text/html;charset=utf-8"))
     }
 
     @Test


### PR DESCRIPTION
Partial implementation of [the Format API proposal](https://github.com/readium/architecture/pull/127).

I figured this could be split in several smaller PRs, so this contains only the `MediaType` part.