### PR TITLE
Publication.links don't require a `rel`

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -306,7 +306,6 @@ data class Publication(
             }
 
             val links = Link.fromJSONArray(json.remove("links") as? JSONArray, normalizeHref, warnings)
-                .filter { it.rels.isNotEmpty() }
 
             // [readingOrder] used to be [spine], so we parse [spine] as a fallback.
             val readingOrderJSON = (json.remove("readingOrder") ?: json.remove("spine")) as? JSONArray

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -141,30 +141,6 @@ class PublicationTest {
         )
     }
 
-    @Test fun `parse JSON ignores {links} without {rel}`() {
-        assertEquals(
-            Publication(
-                metadata = Metadata(localizedTitle = LocalizedString("Title")),
-                links = listOf(
-                    Link(href = "/manifest.json", rels = setOf("self")),
-                    Link(href = "/withrel", rels = setOf("withrel"))
-                ),
-                readingOrder = listOf(Link(href = "/chap1.html", type = "text/html"))
-            ),
-            Publication.fromJSON(JSONObject("""{
-                "metadata": {"title": "Title"},
-                "links": [
-                    {"href": "/manifest.json", "rel": "self"},
-                    {"href": "/withrel", "rel": "withrel"},
-                    {"href": "/withoutrel"}
-                ],
-                "readingOrder": [
-                    {"href": "/chap1.html", "type": "text/html"}
-                ]
-            }"""))
-        )
-    }
-
     @Test fun `parse JSON ignores {readingOrder} without {type}`() {
         assertEquals(
             Publication(


### PR DESCRIPTION
I filtered out `Link` without a `rel` in `Publication.links`, but nothing states that they *must* have a `rel` in the RWPM spec.