### PR TITLE
Rename `UND` into `und`

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/LocalizedString.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/LocalizedString.kt
@@ -101,7 +101,7 @@ data class LocalizedString(val translations: Map<String?, Translation> = emptyMa
         /**
          * BCP-47 tag for an undefined language.
          */
-        const val UNDEFINED_LANGUAGE = "UND"
+        const val UNDEFINED_LANGUAGE = "und"
 
         /**
          * Shortcut to create a [LocalizedString] using a map of translations indexed by the BCP 47

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/ContributorTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/ContributorTest.kt
@@ -156,7 +156,7 @@ class ContributorTest {
 
     @Test fun `get minimal JSON`() {
         assertJSONEquals(
-            JSONObject("{'name': {'UND': 'Colin Greenwood'}}"),
+            JSONObject("{'name': {'und': 'Colin Greenwood'}}"),
             Contributor(localizedName = LocalizedString("Colin Greenwood"))
                 .toJSON()
         )
@@ -165,9 +165,9 @@ class ContributorTest {
     @Test fun `get full JSON`() {
         assertJSONEquals(
             JSONObject("""{
-                "name": {"UND": "Colin Greenwood"},
+                "name": {"und": "Colin Greenwood"},
                 "identifier": "colin",
-                "sortAs": {"UND": "greenwood"},
+                "sortAs": {"und": "greenwood"},
                 "role": ["bassist"],
                 "position": 4.0,
                 "links": [
@@ -193,7 +193,7 @@ class ContributorTest {
         assertJSONEquals(
             JSONArray("""[
                 {
-                    "name": {"UND": "Thom Yorke"},
+                    "name": {"und": "Thom Yorke"},
                 },
                 {
                     "name": {"en": "Jonny Greenwood", "fr": "Jean Boisvert"},

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/LocalizedStringTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/LocalizedStringTest.kt
@@ -50,7 +50,7 @@ class LocalizedStringTest {
         assertJSONEquals(
             LocalizedString("a string").toJSON(),
             JSONObject("""{
-                "UND": "a string"
+                "und": "a string"
             }""")
         )
     }
@@ -65,7 +65,7 @@ class LocalizedStringTest {
             JSONObject("""{
                 "en": "a string",
                 "fr": "une chaîne",
-                "UND": "Surgh"
+                "und": "Surgh"
             }""")
         )
     }

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
@@ -141,7 +141,7 @@ class MetadataTest {
     @Test fun `get minimal JSON`() {
         assertJSONEquals(
             JSONObject("""{
-                "title": {"UND": "Title"},
+                "title": {"und": "Title"},
                 "readingProgression": "auto"
             }"""),
             Metadata(localizedTitle = LocalizedString("Title")).toJSON()
@@ -160,29 +160,29 @@ class MetadataTest {
                 "language": ["en", "fr"],
                 "sortAs": {"en": "sort key", "fr": "clé de tri"},
                 "subject": [
-                    {"name": {"UND": "Science Fiction"}},
-                    {"name": {"UND": "Fantasy"}}
+                    {"name": {"und": "Science Fiction"}},
+                    {"name": {"und": "Fantasy"}}
                 ],
-                "author": [{"name": {"UND": "Author"}}],
-                "translator": [{"name": {"UND": "Translator"}}],
-                "editor": [{"name": {"UND": "Editor"}}],
-                "artist": [{"name": {"UND": "Artist"}}],
-                "illustrator": [{"name": {"UND": "Illustrator"}}],
-                "letterer": [{"name": {"UND": "Letterer"}}],
-                "penciler": [{"name": {"UND": "Penciler"}}],
-                "colorist": [{"name": {"UND": "Colorist"}}],
-                "inker": [{"name": {"UND": "Inker"}}],
-                "narrator": [{"name": {"UND": "Narrator"}}],
-                "contributor": [{"name": {"UND": "Contributor"}}],
-                "publisher": [{"name": {"UND": "Publisher"}}],
-                "imprint": [{"name": {"UND": "Imprint"}}],
+                "author": [{"name": {"und": "Author"}}],
+                "translator": [{"name": {"und": "Translator"}}],
+                "editor": [{"name": {"und": "Editor"}}],
+                "artist": [{"name": {"und": "Artist"}}],
+                "illustrator": [{"name": {"und": "Illustrator"}}],
+                "letterer": [{"name": {"und": "Letterer"}}],
+                "penciler": [{"name": {"und": "Penciler"}}],
+                "colorist": [{"name": {"und": "Colorist"}}],
+                "inker": [{"name": {"und": "Inker"}}],
+                "narrator": [{"name": {"und": "Narrator"}}],
+                "contributor": [{"name": {"und": "Contributor"}}],
+                "publisher": [{"name": {"und": "Publisher"}}],
+                "imprint": [{"name": {"und": "Imprint"}}],
                 "readingProgression": "rtl",
                 "description": "Description",
                 "duration": 4.24,
                 "numberOfPages": 240,
                 "belongsTo": {
-                    "collection": [{"name": {"UND": "Collection"}}],
-                    "series": [{"name": {"UND": "Series"}}]
+                    "collection": [{"name": {"und": "Collection"}}],
+                    "series": [{"name": {"und": "Series"}}]
                 },
                 "other-metadata1": "value",
                 "other-metadata2": [42]

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -212,7 +212,7 @@ class PublicationTest {
     @Test fun `get minimal JSON`() {
         assertJSONEquals(
             JSONObject("""{
-                "metadata": {"title": {"UND": "Title"}, "readingProgression": "auto"},
+                "metadata": {"title": {"und": "Title"}, "readingProgression": "auto"},
                 "links": [],
                 "readingOrder": []
             }"""),
@@ -228,7 +228,7 @@ class PublicationTest {
         assertJSONEquals(
             JSONObject("""{
                 "@context": ["https://readium.org/webpub-manifest/context.jsonld"],
-                "metadata": {"title": {"UND": "Title"}, "readingProgression": "auto"},
+                "metadata": {"title": {"und": "Title"}, "readingProgression": "auto"},
                 "links": [
                     {"href": "/manifest.json", "rel": ["self"], "templated": false}
                 ],

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/SubjectTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/SubjectTest.kt
@@ -132,7 +132,7 @@ class SubjectTest {
 
     @Test fun `get minimal JSON`() {
         assertJSONEquals(
-            JSONObject("{'name': {'UND': 'Science Fiction'}}"),
+            JSONObject("{'name': {'und': 'Science Fiction'}}"),
             Subject(localizedName = LocalizedString("Science Fiction"))
                 .toJSON()
         )
@@ -141,8 +141,8 @@ class SubjectTest {
     @Test fun `get full JSON`() {
         assertJSONEquals(
             JSONObject("""{
-                "name": {"UND": "Science Fiction"},
-                "sortAs": {"UND": "science-fiction"},
+                "name": {"und": "Science Fiction"},
+                "sortAs": {"und": "science-fiction"},
                 "scheme": "http://scheme",
                 "code": "CODE",
                 "links": [
@@ -167,10 +167,10 @@ class SubjectTest {
         assertJSONEquals(
             JSONArray("""[
                 {
-                    "name": {"UND": "Fantasy"},
+                    "name": {"und": "Fantasy"},
                 },
                 {
-                    "name": {"UND": "Science Fiction"},
+                    "name": {"und": "Science Fiction"},
                     "scheme": "http://scheme"
                 }
             ]"""),


### PR DESCRIPTION
In the BCP47 specification, `und` is lowercase.