### PR TITLE
Make OPDS models Parcelable instead of Serializable

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/opds/Facet.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/opds/Facet.kt
@@ -9,12 +9,12 @@
 
 package org.readium.r2.shared.opds
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.readium.r2.shared.publication.Link
-import java.io.Serializable
 
-
-data class Facet(val title: String) : Serializable {
+@Parcelize
+data class Facet(val title: String) : Parcelable {
     var metadata: OpdsMetadata = OpdsMetadata(title = title)
     var links = mutableListOf<Link>()
-
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/opds/Feed.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/opds/Feed.kt
@@ -9,13 +9,14 @@
 
 package org.readium.r2.shared.opds
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
-import java.io.Serializable
 import java.net.URL
 
-
-data class Feed(val title: String, val type: Int, val href: URL) : Serializable {
+@Parcelize
+data class Feed(val title: String, val type: Int, val href: URL) : Parcelable {
     var metadata: OpdsMetadata = OpdsMetadata(title = title)
     var links: MutableList<Link> = mutableListOf()
     var facets: MutableList<Facet> = mutableListOf()
@@ -30,4 +31,5 @@ data class Feed(val title: String, val type: Int, val href: URL) : Serializable 
     }
 }
 
-data class ParseData(val feed: Feed?, val publication: Publication?, val type: Int) : Serializable
+@Parcelize
+data class ParseData(val feed: Feed?, val publication: Publication?, val type: Int) : Parcelable

--- a/r2-shared/src/main/java/org/readium/r2/shared/opds/Group.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/opds/Group.kt
@@ -9,12 +9,13 @@
 
 package org.readium.r2.shared.opds
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
-import java.io.Serializable
 
-
-data class Group(val title: String) : Serializable {
+@Parcelize
+data class Group(val title: String) : Parcelable {
     var metadata: OpdsMetadata = OpdsMetadata(title = title)
     var links = mutableListOf<Link>()
     var publications = mutableListOf<Publication>()

--- a/r2-shared/src/main/java/org/readium/r2/shared/opds/OpdsMetadata.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/opds/OpdsMetadata.kt
@@ -9,11 +9,12 @@
 
 package org.readium.r2.shared.opds
 
-import java.io.Serializable
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import java.util.*
 
-
-data class OpdsMetadata(var title: String) : Serializable {
+@Parcelize
+data class OpdsMetadata(var title: String) : Parcelable {
     var numberOfItems: Int? = null
     var itemsPerPage: Int? = null
     var currentPage: Int? = null


### PR DESCRIPTION
There was an issue when trying to serialize OPDS models, because sub-models (e.g. `Link`) are actually `Parcelable`.