### PR TITLE
Fix FileFetcher performances

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/ArchiveFetcher.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/ArchiveFetcher.kt
@@ -85,6 +85,9 @@ class ArchiveFetcher private constructor(private val archive: Archive) : Fetcher
         private suspend fun metadataLength(): Long? =
             entry().getOrNull()?.length
 
+        override fun toString(): String =
+            "${javaClass.simpleName}(${archive::class.java.simpleName}, ${originalLink.href})"
+
     }
 }
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/BytesResource.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/BytesResource.kt
@@ -9,6 +9,7 @@
 
 package org.readium.r2.shared.fetcher
 
+import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.extensions.coerceIn
 import org.readium.r2.shared.extensions.requireLengthFitInt
 import org.readium.r2.shared.publication.Link
@@ -46,10 +47,17 @@ class BytesResource(link: Link, bytes: suspend () -> ByteArray) : BaseBytesResou
 
     constructor(link: Link, bytes: ByteArray) : this(link, { bytes })
 
+    override fun toString(): String =
+        "${javaClass.simpleName}(${runBlocking { bytes().size }} bytes)"
+
 }
 
 /** Creates a Resource serving a [String]. */
 class StringResource(link: Link, string: suspend () -> String) : BaseBytesResource(link, { string().toByteArray() }) {
 
     constructor(link: Link, string: String) : this(link, { string })
+
+    override fun toString(): String =
+        "${javaClass.simpleName}(${runBlocking { bytes().toString() }})"
+
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/FileFetcher.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/FileFetcher.kt
@@ -158,5 +158,8 @@ class FileFetcher(private val paths: Map<String, File>) : Fetcher {
                 failure(Resource.Error.Other(e))
             }
 
+        override fun toString(): String =
+            "${javaClass.simpleName}(${file.path})"
+
     }
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
@@ -165,6 +165,10 @@ class FailureResource(private val link: Link, private val error: Resource.Error)
     override suspend fun length():  ResourceTry<Long> = Try.failure(error)
 
     override suspend fun close() {}
+
+    override fun toString(): String =
+        "${javaClass.simpleName}(${error})"
+            
 }
 
 /**
@@ -181,6 +185,10 @@ abstract class ProxyResource(protected val resource: Resource) : Resource {
     override suspend fun read(range: LongRange?): ResourceTry<ByteArray> = resource.read(range)
 
     override suspend fun close() = resource.close()
+
+    override fun toString(): String =
+        "${javaClass.simpleName}($resource)"
+
 }
 
 /**
@@ -229,6 +237,9 @@ class CachingResource(protected val resource: Resource) : Resource {
     }
 
     override suspend fun close() = resource.close()
+
+    override fun toString(): String =
+        "${javaClass.simpleName}($resource)"
 }
 
 /**
@@ -260,6 +271,7 @@ abstract class TransformingResource(resource: Resource) : ProxyResource(resource
         }
 
     override suspend fun length(): ResourceTry<Long> = bytes().map { it.size.toLong() }
+
 }
 
 /**
@@ -286,6 +298,14 @@ class LazyResource(private val factory: suspend () -> Resource) : Resource {
         if (::_resource.isInitialized)
             _resource.close()
     }
+
+    override fun toString(): String =
+        if (::_resource.isInitialized) {
+            "${javaClass.simpleName}($_resource)"
+        } else {
+            "${javaClass.simpleName}(...)"
+        }
+    
 }
 
 /**

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/Benchmarking.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/Benchmarking.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.util
+
+import timber.log.Timber
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
+
+@OptIn(ExperimentalTime::class)
+internal inline fun <T> benchmark(title: String, enabled: Boolean = true, closure: () -> T): T {
+    if (!enabled) {
+        return closure()
+    }
+
+    var result: T
+    val duration = measureTime {
+        result = closure()
+    }
+    Timber.d("""Benchmark "$title" took %.4f seconds """.format(duration.inSeconds))
+    return result
+}

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/Lazy.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/Lazy.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.util
+
+import kotlin.reflect.KProperty0
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Returns true if a lazy property reference has been initialized, or if the property is not lazy.
+ *
+ * Source: https://stackoverflow.com/a/42536189/1474476
+ */
+val KProperty0<*>.isLazyInitialized: Boolean
+    get() {
+        if (this !is Lazy<*>) return true
+
+        // Prevent IllegalAccessException from JVM access check on private properties.
+        val originalAccessLevel = isAccessible
+        isAccessible = true
+        val isLazyInitialized = (getDelegate() as Lazy<*>).isInitialized()
+        // Reset access level.
+        isAccessible = originalAccessLevel
+        return isLazyInitialized
+    }


### PR DESCRIPTION
There was some performance issue when serving a chunked response from a resource created by a `FileFetcher`. Each chunk was first skipping the start of the input stream to the request position, which is relatively slow with the input stream returned by `Channels.newInputStream()`. 

Instead, setting the initial position with `channel.position(range.first)` instead of skipping improves a lot the performances.

(cc @qnga)