### PR TITLE
Add new Resource.Error cases: Cancelled and OutOfMemory

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/FileFetcher.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/FileFetcher.kt
@@ -148,14 +148,14 @@ class FileFetcher(private val paths: Map<String, File>) : Fetcher {
         private inline fun <T> Try.Companion.catching(closure: () -> T): ResourceTry<T> =
             try {
                 success(closure())
-            } catch (e: Resource.Error) {
-                failure(e)
             } catch (e: FileNotFoundException) {
                 failure(Resource.Error.NotFound)
             } catch (e: SecurityException) {
                 failure(Resource.Error.Forbidden)
             } catch (e: Exception) {
-                failure(Resource.Error.Other(e))
+                failure(Resource.Error.wrap(e))
+            } catch (e: OutOfMemoryError) { // We don't want to catch any Error, only OOM.
+                failure(Resource.Error.wrap(e))
             }
 
         override fun toString(): String =

--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
@@ -9,6 +9,7 @@
 
 package org.readium.r2.shared.fetcher
 
+import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
 import org.readium.r2.shared.extensions.coerceIn
 import org.readium.r2.shared.extensions.requireLengthFitInt
@@ -18,7 +19,6 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.util.Try
 import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
-
 
 typealias ResourceTry<SuccessT> = Try<SuccessT, Resource.Error>
 
@@ -148,8 +148,35 @@ interface Resource {
          */
         object Unavailable : Error()
 
+        /**
+         * Equivalent to a 507 HTTP error.
+         *
+         * Used when the requested range is too large to be read in memory.
+         */
+        class OutOfMemory(cause: OutOfMemoryError) : Error(cause)
+
+        /**
+         * The request was cancelled by the caller.
+         *
+         * For example, when a coroutine is cancelled.
+         */
+        object Cancelled : Error()
+
         /** For any other error, such as HTTP 500. */
         class Other(cause: Throwable) : Error(cause)
+
+        companion object {
+
+            fun wrap(e: Throwable): Error =
+                when (e) {
+                    is Error -> e
+                    is CancellationException -> Cancelled
+                    is OutOfMemoryError -> OutOfMemory(e)
+                    else -> Other(e)
+                }
+
+        }
+
     }
 }
 
@@ -316,20 +343,11 @@ class LazyResource(private val factory: suspend () -> Resource) : Resource {
 inline fun <R, S> ResourceTry<S>.mapCatching(transform: (value: S) -> R): ResourceTry<R> =
     try {
         Try.success((transform(getOrThrow())))
-    } catch (e: Resource.Error) {
-        Try.failure(e)
     } catch (e: Exception) {
-        Try.failure(Resource.Error.Other(e))
+        Try.failure(Resource.Error.wrap(e))
+    } catch (e: OutOfMemoryError) { // We don't want to catch any Error, only OOM.
+        Try.failure(Resource.Error.wrap(e))
     }
 
 inline fun <R, S> ResourceTry<S>.flatMapCatching(transform: (value: S) -> ResourceTry<R>): ResourceTry<R> =
     mapCatching(transform).flatMap { it }
-
-internal inline fun <S> Try.Companion.wrap(compute: () -> S): ResourceTry<S> =
-    try {
-        success(compute())
-    } catch (e: Resource.Error) {
-        failure(e)
-    } catch (e: Exception) {
-        failure(Resource.Error.Other(e))
-    }

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/pdf/PdfDocument.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/pdf/PdfDocument.kt
@@ -9,17 +9,14 @@
 
 package org.readium.r2.shared.util.pdf
 
-import android.content.Context
 import android.graphics.Bitmap
 import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.format.MediaType
 import org.readium.r2.shared.publication.Link
-import org.readium.r2.shared.util.archive.Archive
-import org.readium.r2.shared.util.archive.JavaZip
 
 @PdfSupport
-typealias OpenPdfDocument = suspend (Resource) -> PdfDocument?
+typealias OpenPdfDocument = suspend (Resource) -> PdfDocument
 
 /**
  * Represents a PDF document.


### PR DESCRIPTION
Introduce two new `Resource.Error` cases to improve error reporting:

* `Cancelled` occurs when for example a `Resource` operation was cancelled with a parent coroutine.
* `OutOfMemory` wraps a `OutOfMemoryError` caught when trying to read a range of a `Resource` that is too large for the device, to prevent crashes.