### PR TITLE
Add LocatorService

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -28,9 +28,7 @@ import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.publication.epub.listOfAudioClips
 import org.readium.r2.shared.publication.epub.listOfVideoClips
-import org.readium.r2.shared.publication.services.CoverService
-import org.readium.r2.shared.publication.services.PositionsService
-import org.readium.r2.shared.publication.services.positions
+import org.readium.r2.shared.publication.services.*
 import timber.log.Timber
 import java.net.URL
 import java.net.URLEncoder
@@ -322,15 +320,19 @@ class Publication(
      *
      * Provides helpers to manipulate the list of services of a [Publication].
      */
-    class ServicesBuilder(internal var serviceFactories: MutableMap<String, ServiceFactory>) {
+    class ServicesBuilder private constructor(private var serviceFactories: MutableMap<String, ServiceFactory>) {
 
         @Suppress("UNCHECKED_CAST")
         constructor(
-            positions: ServiceFactory? = null,
-            cover: ServiceFactory? = null
+            contentProtection: ServiceFactory? = null,
+            cover: ServiceFactory? = null,
+            locator: ServiceFactory? = { DefaultLocatorService(it.manifest.readingOrder) },
+            positions: ServiceFactory? = null
         ) : this(mapOf(
-            PositionsService::class.java.simpleName to positions,
-            CoverService::class.java.simpleName to cover
+            ContentProtectionService::class.java.simpleName to contentProtection,
+            CoverService::class.java.simpleName to cover,
+            LocatorService::class.java.simpleName to locator,
+            PositionsService::class.java.simpleName to positions
         ).filterValues { it != null }.toMutableMap() as MutableMap<String, ServiceFactory>)
 
         /** Builds the actual list of publication services to use in a Publication. */

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/services/LocatorService.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/services/LocatorService.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.publication.services
+
+import org.readium.r2.shared.publication.*
+import org.readium.r2.shared.publication.ServiceFactory
+
+/**
+ * Locates the destination of various sources (e.g. locators, progression, etc.) in the
+ * publication.
+ *
+ * This service can be used to implement a variety of features, such as:
+ *   - Jumping to a given position or total progression, by converting it first to a [Locator].
+ *   - Converting a [Locator] which was created from an alternate manifest with a different reading
+ *     order. For example, when downloading a streamed manifest or offloading a package.
+ */
+interface LocatorService : Publication.Service {
+
+    /** Locates the target of the given [locator]. */
+    fun locate(locator: Locator): Locator?
+
+    /** Locates the target at the given [progression] relative to the whole publication. */
+    fun locate(progression: Double): Locator?
+
+}
+
+
+/** Locates the target of the given [locator]. */
+fun Publication.locate(locator: Locator): Locator? =
+    findService(LocatorService::class)?.locate(locator)
+
+/** Locates the target at the given [progression] relative to the whole publication. */
+fun Publication.locate(progression: Double): Locator? =
+    findService(LocatorService::class)?.locate(progression)
+
+
+/** Factory to build a [LocatorService] */
+var Publication.ServicesBuilder.locatorServiceFactory: ServiceFactory?
+    get() = get(LocatorService::class)
+    set(value) = set(LocatorService::class, value)
+
+
+open class DefaultLocatorService(val readingOrder: List<Link>) : LocatorService {
+
+    override fun locate(locator: Locator): Locator? =
+        locator.takeIf { readingOrder.firstWithHref(locator.href) != null }
+
+    override fun locate(progression: Double): Locator? = null
+
+}

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -18,10 +18,12 @@ import org.readium.r2.shared.Fixtures
 import org.readium.r2.shared.fetcher.EmptyFetcher
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.fetcher.StringResource
+import org.readium.r2.shared.publication.services.DefaultLocatorService
 import org.readium.r2.shared.publication.services.PositionsService
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import java.net.URL
+import kotlin.reflect.KClass
 
 class PublicationTest {
 
@@ -336,13 +338,13 @@ class PublicationTest {
 
 class ServicesBuilderTest {
 
-    open class FooService: Publication.Service {}
+    open class FooService: Publication.Service
     class FooServiceA: FooService()
     class FooServiceB: FooService()
     class FooServiceC(val wrapped: FooService?): FooService()
 
-    open class BarService: Publication.Service {}
-    class BarServiceA: BarService() {}
+    open class BarService: Publication.Service
+    class BarServiceA: BarService()
 
     private val context = Publication.Service.Context(
         Manifest(metadata = Metadata(localizedTitle = LocalizedString())),
@@ -358,16 +360,16 @@ class ServicesBuilderTest {
             }
             .build(context)
 
-        assertEquals(2, services.size)
-        assertThat(services[0], instanceOf(FooServiceA::class.java))
-        assertThat(services[1], instanceOf(BarServiceA::class.java))
+        assertNotNull(services.find<FooServiceA>())
+        assertNotNull(services.find<BarServiceA>())
     }
 
     @Test
     fun testBuildEmpty() {
         val builder = Publication.ServicesBuilder(cover = null)
         val services = builder.build(context)
-        assertTrue(services.isEmpty())
+        assertEquals(1, services.size)
+        assertNotNull(services.find<DefaultLocatorService>())
     }
 
     @Test
@@ -379,8 +381,8 @@ class ServicesBuilderTest {
             }
             .build(context)
 
-        assertEquals(1, services.size)
-        assertThat(services[0], instanceOf(FooServiceB::class.java))
+        assertNotNull(services.find<FooServiceB>())
+        assertNull(services.find<FooServiceA>())
     }
 
     @Test
@@ -393,8 +395,8 @@ class ServicesBuilderTest {
             }
             .build(context)
 
-        assertEquals(1, services.size)
-        assertThat(services[0], instanceOf(BarServiceA::class.java))
+        assertNotNull(services.find<BarServiceA>())
+        assertNull(services.find<FooServiceA>())
     }
 
     @Test
@@ -406,8 +408,8 @@ class ServicesBuilderTest {
             }
             .build(context)
 
-        assertEquals(1, services.size)
-        assertThat(services[0], instanceOf(FooServiceA::class.java))
+        assertNotNull(services.find<FooServiceA>())
+        assertNull(services.find<BarService>())
     }
 
     @Test
@@ -424,9 +426,12 @@ class ServicesBuilderTest {
             }
             .build(context)
 
-        assertEquals(2, services.size)
-        assertThat(services[0], instanceOf(FooServiceC::class.java))
-        assertThat((services[0] as? FooServiceC)?.wrapped,  instanceOf(FooServiceB::class.java))
-        assertThat(services[1], instanceOf(BarServiceA::class.java))
+        assertNotNull(services.find<FooServiceC>())
+        assertThat(services.find<FooServiceC>()?.wrapped,  instanceOf(FooServiceB::class.java))
+        assertNotNull(services.find<BarServiceA>())
     }
+
+    private inline fun <reified T> List<Publication.Service>.find(): T? =
+        firstOrNull { it is T } as? T
+
 }


### PR DESCRIPTION
Locates the destination of various sources (e.g. locators, progression, etc.) in the publication.

This service is a building block to implement a variety of features, such as:
* Jumping to a given position or total progression, by converting it first to a `Locator`.
* Converting a `Locator` which was created from an alternate manifest with a different reading order. For example, when downloading a streamed manifest or offloading a package.