### PR TITLE
Move flatMap outside of Try

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/Resource.kt
@@ -20,6 +20,7 @@ import org.readium.r2.shared.parser.xml.ElementNode
 import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.flatMap
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.charset.Charset

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/Try.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/Try.kt
@@ -75,12 +75,6 @@ class Try<out Success, out Failure: Throwable> private constructor(private val s
         return this
     }
 
-    inline fun <R, S, F: Throwable> Try<S, F>.flatMap(transform: (value: S) -> Try<R, F>): Try<R, F> =
-        if (isSuccess)
-            transform(getOrThrow())
-        else
-            Try.failure(exceptionOrNull()!!)
-
     /**
      * Returns the encapsulated result of the given transform function applied to the encapsulated |Throwable] exception
      * if this instance represents failure or the original encapsulated value if it is success.
@@ -110,3 +104,9 @@ inline fun <R, S : R, F : Throwable> Try<S, F>.getOrElse(onFailure: (exception: 
         getOrThrow()
     else
         onFailure(exceptionOrNull()!!)
+
+inline fun <R, S, F: Throwable> Try<S, F>.flatMap(transform: (value: S) -> Try<R, F>): Try<R, F> =
+    if (isSuccess)
+        transform(getOrThrow())
+    else
+        Try.failure(exceptionOrNull()!!)


### PR DESCRIPTION
This allows to use flatMap outside the package scope. Otherwise, I was not able to do it.