### PR TITLE
Add LocatorService.locateProgression() and access to the Publication in the Publication Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+
+* `Publication.Service.Context` now holds a reference to the parent `Publication`. This can be used to access other services from a given `Publication.Service` implementation.
+
+
 ## [2.0.0-beta.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ## Added
 
 * `Publication.Service.Context` now holds a reference to the parent `Publication`. This can be used to access other services from a given `Publication.Service` implementation.
+* The default `LocatorService` implementation can be used to get a `Locator` from a global progression in the publication.
+  * `publication.locateProgression(0.5)`
 
 
 ## [2.0.0-beta.1]

--- a/r2-shared/build.gradle
+++ b/r2-shared/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.16.1"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
     testImplementation "org.json:json:20200518"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation "org.robolectric:robolectric:4.3.1"

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -29,6 +29,7 @@ import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.publication.epub.listOfAudioClips
 import org.readium.r2.shared.publication.epub.listOfVideoClips
 import org.readium.r2.shared.publication.services.*
+import org.readium.r2.shared.util.Ref
 import timber.log.Timber
 import java.net.URL
 import java.net.URLEncoder
@@ -45,8 +46,6 @@ internal typealias ServiceFactory = (Publication.Service.Context) -> Publication
  * The default implementation returns Resource.Exception.NotFound for all HREFs.
  * @param servicesBuilder Holds the list of service factories used to create the instances of
  * Publication.Service attached to this Publication.
- * @param type The kind of publication it is ( EPUB, CBZ, ... )
- * @param version The version of the publication, if the type needs any.
  * @param positionsFactory Factory used to build lazily the [positions].
  */
 class Publication(
@@ -65,8 +64,19 @@ class Publication(
     @Deprecated("This will be removed in a future version. Use [Format.of] to check the format of a publication.", level = DeprecationLevel.ERROR)
     var internalData: MutableMap<String, String> = mutableMapOf()
 ) {
-    private val _services: List<Service> = servicesBuilder.build(Service.Context(manifest, fetcher))
-    private val _manifest = manifest.copy(links = manifest.links + _services.map(Service::links).flatten())
+    private val _services: List<Service>
+    private val _manifest: Manifest
+
+    init {
+        // We use a Ref<Publication> instead of passing directly `this` to the services to prevent
+        // them from using the Publication before it is fully initialized.
+        val pubRef = Ref<Publication>()
+
+        _services = servicesBuilder.build(Service.Context(pubRef, manifest, fetcher))
+        _manifest = manifest.copy(links = manifest.links + _services.map(Service::links).flatten())
+
+        pubRef.ref = this
+    }
 
     // Shortcuts to manifest properties
 
@@ -270,8 +280,16 @@ class Publication(
 
         /**
          * Container for the context from which a service is created.
+         *
+         * @param publication Reference to the parent publication.
+         *        Don't store directly the referenced publication, always access it through the
+         *        [Ref] property. The publication won't be set when the service is created or when
+         *        calling [Service.links], but you can use it during regular service operations. If
+         *        you need to initialize your service differently depending on the publication, use
+         *        `manifest`.
          */
         class Context(
+            val publication: Ref<Publication>,
             val manifest: Manifest,
             val fetcher: Fetcher
         )
@@ -302,6 +320,10 @@ class Publication(
          *  - replace a publication resource by its own version.
          *
          * Called by [Publication.get] for each request.
+         *
+         * Warning: If you need to request one of the publication resources to answer the request,
+         * use the [Fetcher] provided by the [Publication.Service.Context] instead of
+         * [Publication.get], otherwise it will trigger an infinite loop.
          *
          * @return The [Resource] containing the response, or null if the service doesn't recognize
          *         this request.

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -348,7 +348,7 @@ class Publication(
         constructor(
             contentProtection: ServiceFactory? = null,
             cover: ServiceFactory? = null,
-            locator: ServiceFactory? = { DefaultLocatorService(it.manifest.readingOrder) },
+            locator: ServiceFactory? = { DefaultLocatorService(it.manifest.readingOrder, it.publication) },
             positions: ServiceFactory? = null
         ) : this(mapOf(
             ContentProtectionService::class.java.simpleName to contentProtection,

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/services/LocatorService.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/services/LocatorService.kt
@@ -8,6 +8,8 @@ package org.readium.r2.shared.publication.services
 
 import org.readium.r2.shared.publication.*
 import org.readium.r2.shared.publication.ServiceFactory
+import org.readium.r2.shared.util.Ref
+import timber.log.Timber
 
 /**
  * Locates the destination of various sources (e.g. locators, progression, etc.) in the
@@ -21,21 +23,21 @@ import org.readium.r2.shared.publication.ServiceFactory
 interface LocatorService : Publication.Service {
 
     /** Locates the target of the given [locator]. */
-    fun locate(locator: Locator): Locator?
+    suspend fun locate(locator: Locator): Locator?
 
-    /** Locates the target at the given [progression] relative to the whole publication. */
-    fun locate(progression: Double): Locator?
+    /** Locates the target at the given [totalProgression] relative to the whole publication. */
+    suspend fun locateProgression(totalProgression: Double): Locator?
 
 }
 
 
 /** Locates the target of the given [locator]. */
-fun Publication.locate(locator: Locator): Locator? =
+suspend fun Publication.locate(locator: Locator): Locator? =
     findService(LocatorService::class)?.locate(locator)
 
 /** Locates the target at the given [progression] relative to the whole publication. */
-fun Publication.locate(progression: Double): Locator? =
-    findService(LocatorService::class)?.locate(progression)
+suspend fun Publication.locateProgression(totalProgression: Double): Locator? =
+    findService(LocatorService::class)?.locateProgression(totalProgression)
 
 
 /** Factory to build a [LocatorService] */
@@ -44,11 +46,104 @@ var Publication.ServicesBuilder.locatorServiceFactory: ServiceFactory?
     set(value) = set(LocatorService::class, value)
 
 
-open class DefaultLocatorService(val readingOrder: List<Link>) : LocatorService {
+open class DefaultLocatorService(val readingOrder: List<Link>, val positionsByReadingOrder: suspend () -> List<List<Locator>>) : LocatorService {
 
-    override fun locate(locator: Locator): Locator? =
+    constructor(readingOrder: List<Link>, publication: Ref<Publication>)
+            : this(readingOrder, positionsByReadingOrder = {
+        publication()?.positionsByReadingOrder() ?: emptyList()
+    })
+
+    override suspend fun locate(locator: Locator): Locator? =
         locator.takeIf { readingOrder.firstWithHref(locator.href) != null }
 
-    override fun locate(progression: Double): Locator? = null
+    override suspend fun locateProgression(totalProgression: Double): Locator? {
+        if (totalProgression !in 0.0..1.0) {
+            Timber.e("Progression must be between 0.0 and 1.0, received $totalProgression)")
+            return null
+        }
+
+        val positions = positionsByReadingOrder()
+        val (readingOrderIndex, position) = findClosestTo(totalProgression, positions)
+            ?: return null
+
+        return position.copyWithLocations(
+            progression = resourceProgressionFor(totalProgression, positions, readingOrderIndex = readingOrderIndex)
+                ?: position.locations.progression,
+            totalProgression = totalProgression
+        )
+    }
+
+    private data class Position(val readingOrderIndex: Int, val locator: Locator)
+
+    /**
+     * Finds the [Locator] in the given [positions] which is the closest to the given
+     * [totalProgression], without exceeding it.
+     */
+    private fun findClosestTo(totalProgression: Double, positions: List<List<Locator>>): Position? {
+        val lastPosition = findLast(positions) ?: return null
+        val lastProgression = lastPosition.item.locations.totalProgression
+        if (lastProgression != null && totalProgression >= lastProgression) {
+            return Position(lastPosition.x, lastPosition.item)
+        }
+
+        fun inBetween(first: Locator, second: Locator): Boolean {
+            val prog1 = first.locations.totalProgression ?: return false
+            val prog2 = second.locations.totalProgression ?: return false
+            return prog1 <= totalProgression && totalProgression < prog2
+        }
+
+        val position = findFirstByPair(positions, ::inBetween) ?: return null
+        return Position(position.x, position.item)
+    }
+
+    /**
+     * Computes the progression relative to a reading order resource at the given index, from its
+     * [totalProgression] relative to the whole publication.
+     */
+    private fun resourceProgressionFor(totalProgression: Double, positions: List<List<Locator>>, readingOrderIndex: Int): Double? {
+        val startProgression = positions[readingOrderIndex].firstOrNull()?.locations?.totalProgression ?: return null
+        val endProgression = positions.getOrNull(readingOrderIndex + 1)?.firstOrNull()?.locations?.totalProgression ?: 1.0
+
+        return when {
+            totalProgression <= startProgression -> 0.0
+            totalProgression >= endProgression -> 1.0
+            else -> (totalProgression - startProgression) / (endProgression - startProgression)
+        }
+    }
+
+    /** Holds an item and its position in a two-dimensional array. */
+    private data class Match<T>(val x: Int, val y: Int, val item: T)
+
+    /* Finds the first item matching the given condition when paired with its successor. */
+    private fun <T> findFirstByPair(items: List<List<T>>, condition: (T, T) -> Boolean): Match<T>? {
+        var previous: Match<T>? = null
+
+        items.forEachIndexed { x, section ->
+            section.forEachIndexed { y, item ->
+                previous?.let { previous ->
+                    if (condition(previous.item, item)) {
+                        return previous
+                    }
+                }
+
+                previous = Match(x = x, y = y, item = item)
+            }
+        }
+
+        return null
+    }
+
+    /** Finds the last item in the last non-empty list of [items]. */
+    private fun <T> findLast(items: List<List<T>>): Match<T>? {
+        var last: Match<T>? = null
+
+        items.forEachIndexed { x, section ->
+            section.forEachIndexed { y, item ->
+                last = Match(x = x, y = y, item = item)
+            }
+        }
+
+        return last
+    }
 
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/Ref.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/Ref.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.util
+
+/**
+ * Smart pointer holding a mutable reference to an object.
+ *
+ * Get the reference by calling `ref()`
+ * Conveniently, the reference can be reset by setting the `ref` property.
+ */
+class Ref<T>(var ref: T? = null) {
+
+    operator fun invoke(): T? = ref
+
+}

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -22,6 +22,7 @@ import org.readium.r2.shared.publication.services.DefaultLocatorService
 import org.readium.r2.shared.publication.services.PositionsService
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
+import org.readium.r2.shared.util.Ref
 import java.net.URL
 import kotlin.reflect.KClass
 
@@ -347,6 +348,7 @@ class ServicesBuilderTest {
     class BarServiceA: BarService()
 
     private val context = Publication.Service.Context(
+        Ref(),
         Manifest(metadata = Metadata(localizedTitle = LocalizedString())),
         EmptyFetcher()
     )

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/services/LocatorServiceTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/services/LocatorServiceTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.publication.services
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LocatorServiceTest {
+
+    // locate(Locator) checks that the href exists.
+    @Test
+    fun `locate from Locator`() = runBlockingTest {
+        val service = createService(readingOrder = listOf(
+            Link(href = "chap1", type = "application/xml"),
+            Link(href = "chap2", type = "application/xml"),
+            Link(href = "chap3", type = "application/xml")
+        ))
+        val locator = Locator(href = "chap2", type = "text/html", text = Locator.Text(highlight = "Highlight"))
+        assertEquals(locator, service.locate(locator))
+    }
+
+    @Test
+    fun `locate from Locator with empty reading order`() = runBlockingTest {
+        val service = createService(readingOrder = emptyList())
+        val locator = Locator(href = "chap2", type = "text/html", text = Locator.Text(highlight = "Highlight"))
+        assertNull(service.locate(locator))
+    }
+
+    @Test
+    fun `locate from Locator not found`() = runBlockingTest {
+        val service = createService(readingOrder = listOf(
+            Link(href = "chap1", type = "application/xml"),
+            Link(href = "chap3", type = "application/xml")
+        ))
+        val locator = Locator(href = "chap2", type = "text/html", text = Locator.Text(highlight = "Highlight"))
+        assertNull(service.locate(locator))
+    }
+
+    @Test
+    fun `locate from progression`() = runBlockingTest {
+        val service = createService(positions = positionsFixtures)
+
+        assertEquals(Locator(
+            href = "chap1",
+            type = "text/html",
+            locations = Locator.Locations(
+                progression = 0.0,
+                totalProgression = 0.0,
+                position = 1
+            )
+        ), service.locateProgression(0.0))
+
+        assertEquals(Locator(
+            href = "chap3",
+            type = "text/html",
+            title = "Chapter 3",
+            locations = Locator.Locations(
+                progression = 0.0,
+                totalProgression = 2.0/8.0,
+                position = 3
+            )
+        ), service.locateProgression(0.25))
+
+        val chap5FirstTotalProg = 5.0/8.0
+        val chap4FirstTotalProg = 3.0/8.0
+
+        assertEquals(Locator(
+            href = "chap4",
+            type = "text/html",
+            locations = Locator.Locations(
+                progression = (0.4 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
+                totalProgression = 0.4,
+                position = 4
+            )
+        ), service.locateProgression(0.4))
+
+        assertEquals(Locator(
+            href = "chap4",
+            type = "text/html",
+            locations = Locator.Locations(
+                progression = (0.55 - chap4FirstTotalProg) / (chap5FirstTotalProg - chap4FirstTotalProg),
+                totalProgression = 0.55,
+                position = 5
+            )
+        ), service.locateProgression(0.55))
+
+        assertEquals(Locator(
+            href = "chap5",
+            type = "text/html",
+            locations = Locator.Locations(
+                progression = (0.9 - chap5FirstTotalProg) / (1.0 - chap5FirstTotalProg),
+                totalProgression = 0.9,
+                position = 8
+            )
+        ), service.locateProgression(0.9))
+
+        assertEquals(Locator(
+            href = "chap5",
+            type = "text/html",
+            locations = Locator.Locations(
+                progression = 1.0,
+                totalProgression = 1.0,
+                position = 8
+            )
+        ), service.locateProgression(1.0))
+    }
+
+    @Test
+    fun `locate from incorrect progression`() = runBlockingTest {
+        val service = createService(positions = positionsFixtures)
+        assertNull(service.locateProgression(-0.2))
+        assertNull(service.locateProgression(1.2))
+    }
+
+    @Test
+    fun `locate from progression with empty positions`() = runBlockingTest {
+        val service = createService(positions = emptyList())
+        assertNull(service.locateProgression(0.5))
+    }
+
+    private fun createService(
+        readingOrder: List<Link> = emptyList(),
+        positions: List<List<Locator>> = emptyList()
+    ) = DefaultLocatorService(
+        readingOrder = readingOrder,
+        positionsByReadingOrder = { positions }
+    )
+
+    private var positionsFixtures = listOf(
+        listOf(
+            Locator(
+                href = "chap1",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 0.0,
+                    position = 1,
+                    totalProgression = 0.0
+                )
+            )
+        ),
+        listOf(
+            Locator(
+                href = "chap2",
+                type = "application/xml",
+                locations = Locator.Locations(
+                    progression = 0.0,
+                    position = 2,
+                    totalProgression = 1.0/8.0
+                )
+            )
+        ),
+        listOf(
+            Locator(
+                href = "chap3",
+                type = "text/html",
+                title = "Chapter 3",
+                locations = Locator.Locations(
+                    progression = 0.0,
+                    position = 3,
+                    totalProgression = 2.0/8.0
+                )
+            )
+        ),
+        listOf(
+            Locator(
+                href = "chap4",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 0.0,
+                    position = 4,
+                    totalProgression = 3.0/8.0
+                )
+            ),
+            Locator(
+                href = "chap4",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 0.5,
+                    position = 5,
+                    totalProgression = 4.0/8.0
+                )
+            )
+        ),
+        listOf(
+            Locator(
+                href = "chap5",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 0.0,
+                    position = 6,
+                    totalProgression = 5.0/8.0
+                )
+            ),
+            Locator(
+                href = "chap5",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 1.0/3.0,
+                    position = 7,
+                    totalProgression = 6.0/8.0
+                )
+            ),
+            Locator(
+                href = "chap5",
+                type = "text/html",
+                locations = Locator.Locations(
+                    progression = 2.0/3.0,
+                    position = 8,
+                    totalProgression = 7.0/8.0
+                )
+            )
+        )
+    )
+
+}


### PR DESCRIPTION
* `Publication.Service.Context` now holds a reference to the parent `Publication`. This can be used to access other services from a given `Publication.Service` implementation.
* The default `LocatorService` implementation can be used to get a `Locator` from a global progression in the publication.
  * `publication.locateProgression(0.5)`