### PR TITLE
Improve performances when reading deflated ZIP resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+* [#129](https://github.com/readium/r2-shared-kotlin/issues/129) Improve performances when reading deflated ZIP resources.
+  * For example, it helps with large image-based FXL EPUB which used to be slow to render.
+
+
 ## [2.0.0-beta.1]
 
 ### Added

--- a/r2-shared/src/main/java/org/readium/r2/shared/fetcher/ArchiveFetcher.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/fetcher/ArchiveFetcher.kt
@@ -82,7 +82,11 @@ class ArchiveFetcher private constructor(private val archive: Archive) : Fetcher
             metadataLength()?.let { Try.success(it) }
                 ?: read().map { it.size.toLong() }
 
-        override suspend fun close() {}
+        override suspend fun close() {
+            if (::_entry.isInitialized) {
+                _entry.onSuccess { it.close() }
+            }
+        }
 
         private suspend fun metadataLength(): Long? =
             entry().getOrNull()?.length

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/archive/Archive.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/archive/Archive.kt
@@ -68,6 +68,11 @@ interface Archive {
          */
         suspend fun read(range: LongRange? = null): ByteArray
 
+        /**
+         * Closes any pending resources for this entry.
+         */
+        suspend fun close()
+
     }
 
     /** List of all the archived file entries. */

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/archive/ExplodedArchive.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/archive/ExplodedArchive.kt
@@ -43,6 +43,9 @@ internal class ExplodedArchive(private val directory: File)  : Archive {
                     it.readRange(range)
             }
         }
+
+        override suspend fun close() {}
+
     }
 
     override suspend fun entries(): List<Archive.Entry> =

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/io/CountingInputStream.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/io/CountingInputStream.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.util.io
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.readium.r2.shared.extensions.coerceFirstNonNegative
+import org.readium.r2.shared.extensions.read
+import org.readium.r2.shared.extensions.requireLengthFitInt
+import java.io.FilterInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.lang.Exception
+
+/**
+ * An [InputStream] counting the number of bytes read from a wrapped [inputStream].
+ */
+class CountingInputStream(inputStream: InputStream) : FilterInputStream(inputStream) {
+
+    var count: Long = 0
+        private set
+
+    private var mark: Long = -1
+
+    override fun read(): Int =
+        super.read()
+            .also {
+                if (it != -1) {
+                    count++
+                }
+            }
+
+    override fun read(b: ByteArray?, off: Int, len: Int): Int =
+        super.read(b, off, len)
+            .also { readLen ->
+                if (readLen != -1) {
+                    count += readLen.toLong()
+                }
+            }
+
+    override fun skip(n: Long): Long =
+        super.skip(n)
+            .also { count += it }
+
+    override fun mark(readlimit: Int) {
+        super.mark(readlimit)
+        mark = count
+    }
+
+    override fun reset() {
+        if (!`in`.markSupported()) {
+            throw IOException("Mark not supported")
+        }
+        if (mark == -1L) {
+            throw IOException("Mark not set")
+        }
+
+        super.reset()
+        count = mark.coerceAtLeast(0)
+    }
+
+    suspend fun readRange(range: LongRange): ByteArray {
+        @Suppress("NAME_SHADOWING")
+        val range = range
+            .coerceFirstNonNegative()
+            .requireLengthFitInt()
+
+        if (range.isEmpty())
+            return ByteArray(0)
+
+        return withContext(Dispatchers.IO) {
+            skip(range.first - count)
+            val length = range.last - range.first + 1
+            read(length)
+        }
+    }
+
+}

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContext.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContext.kt
@@ -191,7 +191,12 @@ class SnifferContext internal constructor(
         val archive = contentAsArchive() ?: return null
 
         return withContext(Dispatchers.IO) {
-            tryOrNull { archive.entry(path).read() }
+            tryOrNull {
+                val entry = archive.entry(path)
+                val bytes = entry.read()
+                entry.close()
+                bytes
+            }
         }
     }
 


### PR DESCRIPTION
Fix #129 

*  Improve performances when reading deflated ZIP resources.
    * For example, it helps with large image-based FXL EPUB which used to be slow to render.

Reading an entry in chunks (e.g. from the HTTP server) can be really slow if the entry is deflated in the archive, because we can't jump to an arbitrary offset in a deflated stream. This means that we need to read from the start of the entry for each chunk.

To alleviate this issue, I cached a stream which will be reused as long as the chunks are requested in order.