### PR TITLE
Fix parsing of legacy DomRange models

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/html/DomRange.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/html/DomRange.kt
@@ -88,6 +88,10 @@ data class DomRange(
                     cssSelector = cssSelector,
                     textNodeIndex = textNodeIndex,
                     charOffset = json.optPositiveInt("charOffset")
+                        // The model was using `offset` before, so we still parse it to ensure
+                        // backward-compatibility for reading apps having persisted legacy Locator
+                        // models.
+                        ?: json.optPositiveInt("offset")
                 )
             }
 

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/html/DomRangeTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/html/DomRangeTest.kt
@@ -108,6 +108,21 @@ class DomRangeTest {
         )
     }
 
+    /**
+     * `offset` got replaced with `charOffset`, but we still need to be able to parse it to ensure
+     * backward-compatibility for apps which persisted legacy versions of the DomRange model.
+      */
+    @Test fun `parse legacy {Point} JSON`() {
+        assertEquals(
+            DomRange.Point(cssSelector = "p", textNodeIndex = 4, charOffset = 32),
+            DomRange.Point.fromJSON(JSONObject("""{
+                "cssSelector": "p",
+                "textNodeIndex": 4,
+                "offset": 32
+            }"""))
+        )
+    }
+
     @Test fun `parse {Point} invalid JSON`() {
         assertNull(DomRange.Point.fromJSON(JSONObject("""{
             "cssSelector": "p"


### PR DESCRIPTION
Fix #141 

@aferditamuriqi I added some unit test but I still would like to add a test with a full legacy `Locator` to make sure that we parse them correctly. Could you leave a sample in a comment? Thanks
