### PR TITLE
Add extensibility in the "belongsTo" RWPM property

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
@@ -267,13 +267,19 @@ data class Metadata(
             val duration = json.optPositiveDouble("duration", remove = true)
             val numberOfPages = json.optPositiveInt("numberOfPages", remove = true)
 
-            val belongsTo = (
+            val belongsToJson = (
                 json.remove("belongsTo") as? JSONObject ?:
-                json.remove("belongs_to") as? JSONObject
+                json.remove("belongs_to") as? JSONObject ?:
+                JSONObject()
             )
-                ?.toMap()
-                ?.mapValues { Collection.fromJSONArray(it.value, normalizeHref, warnings) }
-                ?: emptyMap()
+
+            val belongsTo = mutableMapOf<String, List<Collection>>()
+            for (key in belongsToJson.keys()) {
+                if (!belongsToJson.isNull(key)) {
+                    val value = belongsToJson.get(key)
+                    belongsTo[key] = Collection.fromJSONArray(value, normalizeHref, warnings)
+                }
+            }
 
             return Metadata(
                 identifier = identifier,
@@ -302,7 +308,7 @@ data class Metadata(
                 description = description,
                 duration = duration,
                 numberOfPages = numberOfPages,
-                belongsTo = belongsTo,
+                belongsTo = belongsTo.toMap(),
                 otherMetadata = json.toMap()
             )
         }

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Metadata.kt
@@ -18,6 +18,7 @@ import org.readium.r2.shared.JSONable
 import org.readium.r2.shared.extensions.*
 import org.readium.r2.shared.publication.presentation.Presentation
 import org.readium.r2.shared.publication.presentation.presentation
+import org.readium.r2.shared.toJSON
 import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.util.logging.log
 import java.util.*
@@ -58,10 +59,81 @@ data class Metadata(
     val description: String? = null,
     val duration: Double? = null,
     val numberOfPages: Int? = null,
-    val belongsToCollections: List<Collection> = emptyList(),
-    val belongsToSeries: List<Collection> = emptyList(),
+    val belongsTo: Map<String, List<Collection>> = emptyMap(),
     val otherMetadata: @WriteWith<JSONParceler> Map<String, Any> = mapOf()
 ) : JSONable, Parcelable {
+
+    constructor(
+        identifier: String? = null, // URI
+        type: String? = null, // URI (@type)
+        localizedTitle: LocalizedString,
+        localizedSubtitle: LocalizedString? = null,
+        localizedSortAs: LocalizedString? = null,
+        modified: Date? = null,
+        published: Date? = null,
+        languages: List<String> = emptyList(), // BCP 47 tag
+        subjects: List<Subject> = emptyList(),
+        authors: List<Contributor> = emptyList(),
+        translators: List<Contributor> = emptyList(),
+        editors: List<Contributor> = emptyList(),
+        artists: List<Contributor> = emptyList(),
+        illustrators: List<Contributor> = emptyList(),
+        letterers: List<Contributor> = emptyList(),
+        pencilers: List<Contributor> = emptyList(),
+        colorists: List<Contributor> = emptyList(),
+        inkers: List<Contributor> = emptyList(),
+        narrators: List<Contributor> = emptyList(),
+        contributors: List<Contributor> = emptyList(),
+        publishers: List<Contributor> = emptyList(),
+        imprints: List<Contributor> = emptyList(),
+        readingProgression: ReadingProgression = ReadingProgression.AUTO,
+        description: String? = null,
+        duration: Double? = null,
+        numberOfPages: Int? = null,
+        belongsTo: Map<String, List<Collection>> = emptyMap(),
+        belongsToCollections: List<Collection> = emptyList(),
+        belongsToSeries: List<Collection> = emptyList(),
+        otherMetadata: Map<String, Any> = mapOf()
+    ): this(
+        identifier = identifier,
+        type = type,
+        localizedTitle = localizedTitle,
+        localizedSubtitle = localizedSubtitle,
+        localizedSortAs = localizedSortAs,
+        modified = modified,
+        published = published,
+        languages = languages,
+        subjects = subjects,
+        authors = authors,
+        translators = translators,
+        editors = editors,
+        artists = artists,
+        illustrators = illustrators,
+        letterers = letterers,
+        pencilers = pencilers,
+        colorists = colorists,
+        inkers = inkers,
+        narrators = narrators,
+        contributors = contributors,
+        publishers = publishers,
+        imprints = imprints,
+        readingProgression = readingProgression,
+        description = description,
+        duration = duration,
+        numberOfPages = numberOfPages,
+        belongsTo = belongsTo
+            .toMutableMap()
+            .apply {
+                if (belongsToCollections.isNotEmpty()) {
+                    this["collection"] = belongsToCollections
+                }
+                if (belongsToSeries.isNotEmpty()) {
+                    this["series"] = belongsToSeries
+                }
+            }
+            .toMap(),
+        otherMetadata = otherMetadata
+    )
 
     /**
      * Returns the default translation string for the [localizedTitle].
@@ -73,6 +145,12 @@ data class Metadata(
      * Returns the default translation string for the [localizedSortAs].
      */
     val sortAs: String? get() = localizedSortAs?.string
+
+    val belongsToCollections: List<Collection> get() =
+        belongsTo["collection"] ?: emptyList()
+
+    val belongsToSeries: List<Collection> get() =
+        belongsTo["series"] ?: emptyList()
 
     /**
      * Computes a [ReadingProgression] when the value of [readingProgression] is set to
@@ -135,10 +213,7 @@ data class Metadata(
         put("description", description)
         put("duration", duration)
         put("numberOfPages", numberOfPages)
-        putIfNotEmpty("belongsTo", JSONObject().apply {
-            putIfNotEmpty("collection", belongsToCollections)
-            putIfNotEmpty("series", belongsToSeries)
-        })
+        putIfNotEmpty("belongsTo", belongsTo)
     }
 
     /**
@@ -191,10 +266,14 @@ data class Metadata(
             val description = json.remove("description") as? String
             val duration = json.optPositiveDouble("duration", remove = true)
             val numberOfPages = json.optPositiveInt("numberOfPages", remove = true)
-            val belongsTo = json.remove("belongsTo") as? JSONObject
-                ?: json.remove("belongs_to") as? JSONObject
-            val belongsToCollections = Collection.fromJSONArray(belongsTo?.opt("collection"), normalizeHref, warnings)
-            val belongsToSeries = Collection.fromJSONArray(belongsTo?.opt("series"), normalizeHref, warnings)
+
+            val belongsTo = (
+                json.remove("belongsTo") as? JSONObject ?:
+                json.remove("belongs_to") as? JSONObject
+            )
+                ?.toMap()
+                ?.mapValues { Collection.fromJSONArray(it.value, normalizeHref, warnings) }
+                ?: emptyMap()
 
             return Metadata(
                 identifier = identifier,
@@ -223,8 +302,7 @@ data class Metadata(
                 description = description,
                 duration = duration,
                 numberOfPages = numberOfPages,
-                belongsToCollections = belongsToCollections,
-                belongsToSeries = belongsToSeries,
+                belongsTo = belongsTo,
                 otherMetadata = json.toMap()
             )
         }
@@ -260,10 +338,6 @@ data class Metadata(
 
     @Deprecated("Not used anymore", ReplaceWith("null"))
     val rights: String? get() = null
-
-    @Deprecated("Use either [belongsToCollections] or [belongsToSeries] instead", ReplaceWith("belongsToCollections"))
-    val belongsTo: Unit
-        get() = Unit
 
     @Deprecated("Renamed into [toJSON]", ReplaceWith("toJSON()"))
     fun writeJSON(): JSONObject = toJSON()

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
@@ -59,6 +59,7 @@ class MetadataTest {
                 description = "Description",
                 duration = 4.24,
                 numberOfPages = 240,
+                belongsTo = mapOf("schema:Periodical" to listOf(Contributor(name = "Periodical"))),
                 belongsToCollections = listOf(Contributor(name = "Collection")),
                 belongsToSeries = listOf(Contributor(name = "Series")),
                 otherMetadata = mapOf(
@@ -95,7 +96,8 @@ class MetadataTest {
                 "numberOfPages": 240,
                 "belongsTo": {
                     "collection": "Collection",
-                    "series": "Series"
+                    "series": "Series",
+                    "schema:Periodical": "Periodical"
                 },
                 "other-metadata1": "value",
                 "other-metadata2": [42]
@@ -182,7 +184,8 @@ class MetadataTest {
                 "numberOfPages": 240,
                 "belongsTo": {
                     "collection": [{"name": {"und": "Collection"}}],
-                    "series": [{"name": {"und": "Series"}}]
+                    "series": [{"name": {"und": "Series"}}],
+                    "schema:Periodical": [{"name": {"und": "Periodical"}}]
                 },
                 "other-metadata1": "value",
                 "other-metadata2": [42]
@@ -223,6 +226,7 @@ class MetadataTest {
                 description = "Description",
                 duration = 4.24,
                 numberOfPages = 240,
+                belongsTo = mapOf("schema:Periodical" to listOf(Contributor(name = "Periodical"))),
                 belongsToCollections = listOf(Contributor(name = "Collection")),
                 belongsToSeries = listOf(Contributor(name = "Series")),
                 otherMetadata = mapOf(

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/MetadataTest.kt
@@ -59,7 +59,13 @@ class MetadataTest {
                 description = "Description",
                 duration = 4.24,
                 numberOfPages = 240,
-                belongsTo = mapOf("schema:Periodical" to listOf(Contributor(name = "Periodical"))),
+                belongsTo = mapOf(
+                    "schema:Periodical" to listOf(Contributor(name = "Periodical")),
+                    "schema:Newspaper" to listOf(
+                        Contributor(name = "Newspaper 1"),
+                        Contributor(name = "Newspaper 2")
+                    )
+                ),
                 belongsToCollections = listOf(Contributor(name = "Collection")),
                 belongsToSeries = listOf(Contributor(name = "Series")),
                 otherMetadata = mapOf(
@@ -97,7 +103,8 @@ class MetadataTest {
                 "belongsTo": {
                     "collection": "Collection",
                     "series": "Series",
-                    "schema:Periodical": "Periodical"
+                    "schema:Periodical": "Periodical",
+                    "schema:Newspaper": [ "Newspaper 1", "Newspaper 2" ]
                 },
                 "other-metadata1": "value",
                 "other-metadata2": [42]


### PR DESCRIPTION
Useful to access extra collections besides "collection" and "series", for example:

```json
{
  "metadata": {
    "belongsTo": {
      "schema:Periodical": {
        "name": "Magazine A",
        "identifier": "URN:ISSN:0021-752X"
      }
    }
  }
}
```