### PR TITLE
Fix crash with HttpRequest.setPostForm() on Android 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Fixed
+
+* Crash with `HttpRequest.setPostForm()` on Android 6.
+
 
 ## [2.0.0]
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/http/HttpRequest.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/http/HttpRequest.kt
@@ -3,7 +3,6 @@ package org.readium.r2.shared.util.http
 import android.net.Uri
 import java.io.Serializable
 import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -114,7 +113,7 @@ class HttpRequest(
 
             body = Body.Bytes(form
                 .map { (key, value) ->
-                    "$key=${URLEncoder.encode(value ?: "", StandardCharsets.UTF_8.toString())}"
+                    "$key=${URLEncoder.encode(value ?: "", "UTF-8")}"
                 }
                 .joinToString("&")
                 .toByteArray()


### PR DESCRIPTION
`StandardCharsets.UTF_8.toString()` crashes before Java 7.