### PR TITLE
Add a Properties.authenticate helper

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/opds/Properties.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/opds/Properties.kt
@@ -11,6 +11,7 @@ package org.readium.r2.shared.publication.opds
 
 import org.json.JSONObject
 import org.readium.r2.shared.opds.*
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Properties
 
 // OPDS extensions for link [Properties].
@@ -69,3 +70,13 @@ val Properties.copies: Copies?
 val Properties.availability: Availability?
     get() = (this["availability"] as? Map<*, *>)
         ?.let { Availability.fromJSON(JSONObject(it)) }
+
+/**
+ * Indicates that the linked resource supports authentication with the associated Authentication
+ * Document.
+ *
+ * See https://drafts.opds.io/authentication-for-opds-1.0.html
+ */
+val Properties.authenticate: Link?
+    get() = (this["authenticate"] as? Map<*, *>)
+        ?.let { Link.fromJSON(JSONObject(it)) }

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/opds/PropertiesTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/opds/PropertiesTest.kt
@@ -9,9 +9,11 @@
 
 package org.readium.r2.shared.publication.opds
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.readium.r2.shared.opds.*
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Properties
 
 class PropertiesTest {
@@ -90,6 +92,31 @@ class PropertiesTest {
 
     @Test fun `get Properties {availability} when missing`() {
         assertNull(Properties().availability)
+    }
+
+    @Test fun `get Properties {authenticate} when missing`() {
+        assertNull(Properties().authenticate)
+    }
+
+    @Test fun `get Properties {authenticate} when available`() {
+        assertEquals(
+            Link(
+                href = "https://example.com/authentication.json",
+                type = "application/opds-authentication+json"
+            ),
+            Properties(otherProperties = mapOf("authenticate" to mapOf(
+                "href" to "https://example.com/authentication.json",
+                "type" to "application/opds-authentication+json",
+            ))).authenticate
+        )
+    }
+
+    @Test fun `get Properties {authenticate} when invalid`() {
+        assertNull(
+            Properties(otherProperties = mapOf("authenticate" to mapOf(
+                "type" to "application/opds-authentication+json",
+            ))).authenticate
+        )
     }
 
 }


### PR DESCRIPTION
New helper for the new Properties object `authenticate` OPDS extension:

```json
{
  "rel": "self",
  "href": "publication.json",
  "type": "application/opds-publication+json",
  "properties": {
    "authenticate": {
      "href": "https://example.com/authentication.json",
      "type": "application/opds-authentication+json"
    }
  }
}
```

This can be used to pre-authenticate a request in an OPDS feed.