### PR TITLE
Warnings cleanup and dependency updates

### DIFF
--- a/r2-shared/build.gradle
+++ b/r2-shared/build.gradle
@@ -66,7 +66,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.4.31"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-    testImplementation "org.json:json:20210307"
+    // Latest version of org.json is incompatible with the one bundled in Android, breaking the tests.
+    //noinspection GradleDependency
+    testImplementation "org.json:json:20200518"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation "xmlpull:xmlpull:1.1.3.1"

--- a/r2-shared/build.gradle
+++ b/r2-shared/build.gradle
@@ -27,6 +27,7 @@ android {
     }
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        allWarningsAsErrors = true
     }
     testOptions {
         unitTests.includeAndroidResources = true

--- a/r2-shared/build.gradle
+++ b/r2-shared/build.gradle
@@ -25,6 +25,9 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
     testOptions {
         unitTests.includeAndroidResources = true
     }
@@ -39,11 +42,11 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    implementation "androidx.appcompat:appcompat:1.3.0-rc01"
+    implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "com.github.kittinunf.fuel:fuel-android:2.2.2"
     implementation "com.github.kittinunf.fuel:fuel:2.2.2"
     implementation "com.jakewharton.timber:timber:4.7.1"
-    implementation "joda-time:joda-time:2.10.5"
+    implementation "joda-time:joda-time:2.10.10"
     implementation "nl.komponents.kovenant:kovenant-android:3.3.0"
     implementation "nl.komponents.kovenant:kovenant-combine:3.3.0"
     implementation "nl.komponents.kovenant:kovenant-core:3.3.0"

--- a/r2-shared/build.gradle
+++ b/r2-shared/build.gradle
@@ -53,8 +53,8 @@ dependencies {
     implementation "nl.komponents.kovenant:kovenant-functional:3.3.0"
     implementation "nl.komponents.kovenant:kovenant-jvm:3.3.0"
     implementation "nl.komponents.kovenant:kovenant:3.3.0"
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.31"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
     implementation "org.jsoup:jsoup:1.13.1"
 
     testImplementation "androidx.test.ext:junit-ktx:1.1.2"
@@ -62,10 +62,10 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation "net.sf.kxml:kxml2:2.3.0"
     testImplementation 'org.assertj:assertj-core:3.19.0'
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.4.31"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-    testImplementation "org.json:json:20200518"
+    testImplementation "org.json:json:20210307"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation "xmlpull:xmlpull:1.1.3.1"

--- a/r2-shared/src/main/java/org/readium/r2/shared/UserProperties.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/UserProperties.kt
@@ -77,8 +77,7 @@ class UserProperties : Serializable {
         properties.add(Enumerable(index, values, ref, name))
     }
 
-    fun <T : UserProperty> getByRef(ref: String) = properties.firstOrNull {
+    inline fun <reified T : UserProperty> getByRef(ref: String) = properties.firstOrNull {
         it.ref == ref
     }!! as T
 }
-

--- a/r2-shared/src/main/java/org/readium/r2/shared/extensions/Intent.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/extensions/Intent.kt
@@ -65,6 +65,11 @@ fun Intent.getPublicationOrNull(): Publication? {
     return getStringExtra(extraKey)?.let { PublicationRepository.get(it) }
 }
 
+@Suppress("UNUSED_PARAMETER")
+@Deprecated("The `activity` parameter is not necessary", ReplaceWith("getPublicationOrNull()"), level = DeprecationLevel.WARNING)
+fun Intent.getPublicationOrNull(activity: Activity): Publication? =
+    getPublicationOrNull()
+
 fun Intent.destroyPublication(activity: Activity?) {
     if (activity == null || activity.isFinishing) {
         getStringExtra(extraKey)?.let {

--- a/r2-shared/src/main/java/org/readium/r2/shared/extensions/Intent.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/extensions/Intent.kt
@@ -53,7 +53,7 @@ fun Intent.getPublication(activity: Activity?): Publication {
     return publication
 }
 
-fun Intent.getPublicationOrNull(activity: Activity): Publication? {
+fun Intent.getPublicationOrNull(): Publication? {
     if (hasExtra("publication")) {
         if (BuildConfig.DEBUG) {
             throw deprecationException

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/Publication.kt
@@ -265,6 +265,7 @@ class Publication(
         fun localUrlOf(filename: String, port: Int, href: String): String =
             localBaseUrlOf(filename, port) + href
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Parse a RWPM with [Manifest::fromJSON] and then instantiate a Publication",
             ReplaceWith("Manifest.fromJSON(json)",
                 "org.readium.r2.shared.publication.Publication", "org.readium.r2.shared.publication.Manifest"),
@@ -467,7 +468,7 @@ class Publication(
      * The provided closure will be used to build the [PositionListFactory], with this being the
      * [Publication].
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "UNUSED_PARAMETER")
     @Deprecated("Use [Publication.copy(serviceFactories)] instead", ReplaceWith("Publication.copy(serviceFactories = listOf(positionsServiceFactory)"), level = DeprecationLevel.ERROR)
     fun copyWithPositionsFactory(createFactory: Publication.() -> PositionListFactory): Publication {
         throw NotImplementedError()
@@ -528,6 +529,7 @@ class Publication(
      * The search order is unspecified.
      */
     @Deprecated("Use [linkWithHref()] to find a link with the given HREF", replaceWith = ReplaceWith("linkWithHref"), level = DeprecationLevel.ERROR)
+    @Suppress("UNUSED_PARAMETER")
     fun link(predicate: (Link) -> Boolean): Link? = null
 
     @Deprecated("Use [jsonManifest] instead", ReplaceWith("jsonManifest"))
@@ -537,6 +539,7 @@ class Publication(
     val contentLayout: ReadingProgression get() = metadata.effectiveReadingProgression
 
     @Deprecated("Use `metadata.effectiveReadingProgression` instead", ReplaceWith("metadata.effectiveReadingProgression"), level = DeprecationLevel.ERROR)
+    @Suppress("UNUSED_PARAMETER")
     fun contentLayoutForLanguage(language: String?) = metadata.effectiveReadingProgression
 
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/MediaType.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/MediaType.kt
@@ -496,21 +496,27 @@ class MediaType(
         @Deprecated("Use [LCP_LICENSE_DOCUMENT] instead", ReplaceWith("MediaType.LCP_LICENSE_DOCUMENT"), level = DeprecationLevel.ERROR)
         val LCP_LICENSE: MediaType get() = LCP_LICENSE_DOCUMENT
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofFile()]", ReplaceWith("MediaType.ofFile(file, mediaType, fileExtension, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(file: File, mediaType: String? = null, fileExtension: String? = null, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofFile()]", ReplaceWith("MediaType.ofFile(file, mediaTypes, fileExtensions, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(file: File, mediaTypes: List<String>, fileExtensions: List<String>, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofBytes()]", ReplaceWith("MediaType.ofBytes(bytes, mediaType, fileExtension, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(bytes: () -> ByteArray, mediaType: String? = null, fileExtension: String? = null, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofBytes()]", ReplaceWith("MediaType.ofBytes(bytes, mediaTypes, fileExtensions, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(bytes: () -> ByteArray, mediaTypes: List<String>, fileExtensions: List<String>, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofUri()]", ReplaceWith("MediaType.ofUri(uri, contentResolver, mediaType, fileExtension, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(uri: Uri, contentResolver: ContentResolver, mediaType: String? = null, fileExtension: String? = null, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 
+        @Suppress("UNUSED_PARAMETER")
         @Deprecated("Renamed to [ofUri()]", ReplaceWith("MediaType.ofUri(uri, contentResolver, mediaTypes, fileExtensions, sniffers)"), level = DeprecationLevel.ERROR)
         fun of(uri: Uri, contentResolver: ContentResolver, mediaTypes: List<String>, fileExtensions: List<String>, sniffers: List<Sniffer> = MediaType.sniffers): MediaType? = null
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/Sniffer.kt
@@ -288,13 +288,13 @@ object Sniffers {
         }
 
         if (context.contentAsArchive() != null) {
-            fun isIgnored(entry: Archive.Entry, file: File): Boolean =
+            fun isIgnored(file: File): Boolean =
                 file.name.startsWith(".") || file.name == "Thumbs.db"
 
             suspend fun archiveContainsOnlyExtensions(fileExtensions: List<String>): Boolean =
                 context.archiveEntriesAllSatisfy { entry ->
                     val file = File(entry.path)
-                    isIgnored(entry, file) || fileExtensions.contains(file.extension.toLowerCase(Locale.ROOT))
+                    isIgnored(file) || fileExtensions.contains(file.extension.toLowerCase(Locale.ROOT))
                 }
 
             if (archiveContainsOnlyExtensions(CBZ_EXTENSIONS)) {

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/PublicationTest.kt
@@ -429,7 +429,7 @@ class ServicesBuilderTest {
             .build(context)
 
         assertNotNull(services.find<FooServiceC>())
-        assertThat(services.find<FooServiceC>()?.wrapped,  instanceOf(FooServiceB::class.java))
+        assertTrue(services.find<FooServiceC>()?.wrapped is FooServiceB)
         assertNotNull(services.find<BarServiceA>())
     }
 

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/services/CoverServiceTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/services/CoverServiceTest.kt
@@ -75,7 +75,7 @@ class CoverServiceTest {
 
     @Test
     fun `helper for ServicesBuilder works fine`() {
-        val factory = { context: Publication.Service.Context ->
+        val factory = { _: Publication.Service.Context ->
             object : CoverService {
                 override suspend fun cover(): Bitmap? = null
             }

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/services/PositionsServiceTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/services/PositionsServiceTest.kt
@@ -71,9 +71,6 @@ class PositionsServiceTest {
             override suspend fun positionsByReadingOrder(): List<List<Locator>> = positions
         }
 
-        val t = service.get(Link("/~readium/positions"))
-            ?.let { runBlocking { it.readAsString() } }
-
         val json = service.get(Link("/~readium/positions"))
             ?.let { runBlocking { it.readAsString() } }
             ?.getOrNull()
@@ -92,7 +89,7 @@ class PositionsServiceTest {
 
     @Test
     fun `helper for ServicesBuilder works fine`() {
-        val factory = { context: Publication.Service.Context ->
+        val factory = { _: Publication.Service.Context ->
             object : PositionsService {
                 override suspend fun positionsByReadingOrder(): List<List<Locator>> = emptyList()
             }


### PR DESCRIPTION
Cleaned up warnings by doing the following: 

* Replaced deprecated code
* Annotated unused parameters for deprecated functions
* Removed unused parameters from non-deprecated functions
* Added `freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"` to kotlinOptions
* Modified functions with type cast warnings

Dependencies were also updated.