### PR TITLE
Fix sniffing the media type of a RWPM larger than 100KB

### DIFF
--- a/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContent.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/mediatype/SnifferContent.kt
@@ -35,8 +35,8 @@ internal class SnifferFileContent(val file: File) : SnifferContent {
 
     override suspend fun read(): ByteArray? = withContext(Dispatchers.IO) {
         try {
-            // We only read files smaller than 100KB to avoid an [OutOfMemoryError].
-            if (file.length() > 100000) {
+            // We only read files smaller than 5MB to avoid an [OutOfMemoryError].
+            if (file.length() > 5 * 1000 * 1000) {
                 null
             } else {
                 file.readBytes()


### PR DESCRIPTION
Raises the maximum content length of sniffed content to 5MB. 100KB was too small, in the wild a RWPM can get larger than this.