### PR TITLE
Add ContentProtection.Scheme to identify DRM technologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * (*alpha*) A new Publication `SearchService` to search through the resources' content, with a default implementation `StringSearchService`.
+* `ContentProtection.Scheme` can be used to identify protection technologies using unique URI identifiers.
 
 ### Changed
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/UserException.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/UserException.kt
@@ -22,10 +22,10 @@ open class UserException protected constructor(
     cause: Throwable?
 ) : Exception(cause) {
 
-    constructor(@StringRes userMessageId: Int, vararg args: Any, cause: Throwable? = null)
+    constructor(@StringRes userMessageId: Int, vararg args: Any?, cause: Throwable? = null)
         : this(Content(userMessageId, *args), cause)
 
-    constructor(@PluralsRes userMessageId: Int, quantity: Int?, vararg args: Any, cause: Throwable? = null)
+    constructor(@PluralsRes userMessageId: Int, quantity: Int?, vararg args: Any?, cause: Throwable? = null)
         : this(Content(userMessageId, quantity, *args), cause)
 
     constructor(message: String, cause: Throwable? = null)
@@ -64,7 +64,7 @@ open class UserException protected constructor(
          * @param args Optional arguments to expand in the message.
          * @param quantity Quantity to use if the user message is a quantity strings.
          */
-        class LocalizedString(private val userMessageId: Int, private val args: Array<out Any>, private val quantity: Int?) : Content() {
+        class LocalizedString(private val userMessageId: Int, private val args: Array<out Any?>, private val quantity: Int?) : Content() {
             override fun getUserMessage(context: Context, cause: Throwable?, includesCauses: Boolean): String {
                 // Convert complex objects to strings, such as Date, to be interpolated.
                 val args = args.map { arg ->
@@ -98,9 +98,9 @@ open class UserException protected constructor(
         }
 
         companion object {
-            operator fun invoke(@StringRes userMessageId: Int, vararg args: Any) =
+            operator fun invoke(@StringRes userMessageId: Int, vararg args: Any?) =
                 LocalizedString(userMessageId, args, null)
-            operator fun invoke(@PluralsRes userMessageId: Int, quantity: Int?, vararg args: Any) =
+            operator fun invoke(@PluralsRes userMessageId: Int, quantity: Int?, vararg args: Any?) =
                 LocalizedString(userMessageId, args, quantity)
             operator fun invoke(cause: UserException) =
                 Exception(cause)

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/ContentProtection.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/ContentProtection.kt
@@ -9,6 +9,9 @@
 
 package org.readium.r2.shared.publication
 
+import androidx.annotation.StringRes
+import org.readium.r2.shared.R
+import org.readium.r2.shared.UserException
 import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.publication.asset.PublicationAsset
 import org.readium.r2.shared.publication.services.ContentProtectionService
@@ -76,4 +79,35 @@ interface ContentProtection {
         val onCreatePublication: Publication.Builder.() -> Unit = {}
     )
 
+    /**
+     * Represents a specific Content Protection technology, uniquely identified with an [uri].
+     */
+    class Scheme(
+        val uri: String,
+        val name: LocalizedString?
+    ) {
+        override fun hashCode(): Int = uri.hashCode()
+        override fun equals(other: Any?): Boolean = (other as? Scheme)?.uri == uri
+
+        companion object {
+            /** Readium LCP DRM scheme. */
+            val Lcp = Scheme(uri = "http://readium.org/2014/01/lcp", name = LocalizedString("Readium LCP"))
+            /** Adobe ADEPT DRM scheme. */
+            val Adept = Scheme(uri = "http://ns.adobe.com/adept", name = LocalizedString("Adobe ADEPT"))
+        }
+    }
+
+    sealed class Exception(userMessageId: Int, vararg args: Any?, quantity: Int? = null, cause: Throwable? = null) : UserException(userMessageId, quantity, *args, cause = cause) {
+        constructor(@StringRes userMessageId: Int, vararg args: Any?, cause: Throwable? = null) : this(userMessageId, *args, quantity = null, cause = cause)
+
+        /**
+         * Exception returned when the given Content Protection [scheme] is not supported by the
+         * app.
+         */
+        class SchemeNotSupported(val scheme: Scheme? = null) : Exception(
+            if (scheme?.name == null) R.string.r2_shared_publication_content_protection_exception_not_supported_unknown
+            else R.string.r2_shared_publication_content_protection_exception_not_supported,
+            scheme?.name?.string
+        )
+    }
 }

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/services/ContentProtectionService.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/services/ContentProtectionService.kt
@@ -16,12 +16,8 @@ import org.readium.r2.shared.extensions.queryParameters
 import org.readium.r2.shared.fetcher.FailureResource
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.fetcher.StringResource
-import org.readium.r2.shared.publication.Link
-import org.readium.r2.shared.publication.LocalizedString
-import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.ServiceFactory
-import java.lang.IllegalArgumentException
-import java.util.Locale
+import org.readium.r2.shared.publication.*
+import java.util.*
 
 /**
  * Provides information about a publication's content protection and manages user rights.
@@ -50,10 +46,15 @@ interface ContentProtectionService: Publication.Service {
     val rights: UserRights
 
     /**
+     * Known technology for this type of Content Protection.
+     */
+    val scheme: ContentProtection.Scheme? get() = null
+
+    /**
      * User-facing name for this Content Protection, e.g. "Readium LCP".
      * It could be used in a sentence such as "Protected by {name}"
      */
-    val name: LocalizedString?
+    val name: LocalizedString? get() = scheme?.name
 
     override val links: List<Link>
         get() = RouteHandler.links
@@ -204,6 +205,12 @@ val Publication.credentials: String?
 val Publication.rights: ContentProtectionService.UserRights
     get() = protectionService?.rights
         ?: ContentProtectionService.UserRights.Unrestricted
+
+/**
+ * Known technology for this type of Content Protection.
+ */
+val Publication.protectionScheme: ContentProtection.Scheme?
+    get() = protectionService?.scheme
 
 /**
  * User-facing localized name for this Content Protection, e.g. "Readium LCP".

--- a/r2-shared/src/main/res/values/strings.xml
+++ b/r2-shared/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="r2.shared.publication.opening_exception.unavailable">Not available, please try again later</string>
     <string name="r2.shared.publication.opening_exception.incorrect_credentials">Provided credentials were incorrect</string>
 
+    <string name="r2.shared.publication.content_protection.exception.not_supported">This publication cannot be opened because it is protected with %1$s</string>
+    <string name="r2.shared.publication.content_protection.exception.not_supported.unknown">This publication cannot be opened because it is protected with an unknown DRM</string>
+
     <string name="r2.shared.resource.exception.bad_request">Invalid request which can\'t be processed</string>
     <string name="r2.shared.resource.exception.not_found">Resource not found</string>
     <string name="r2.shared.resource.exception.forbidden">You are not allowed to access the resource</string>


### PR DESCRIPTION
### Added

* `ContentProtection.Scheme` can be used to identify protection technologies using unique URI identifiers.