### PR TITLE
Add Link properties for archive entry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * (*alpha*) A new Publication `SearchService` to search through the resources' content, with a default implementation `StringSearchService`.
+* `Link` objects from archive-based publication assets (e.g. an EPUB/ZIP) have additional properties for entry metadata.
+    ```json
+    "properties" {
+        "archive": {
+            "entryLength": 8273,
+            "isEntryCompressed": true
+        }
+    }
+    ```
 
 ### Changed
 

--- a/r2-shared/src/main/java/org/readium/r2/shared/publication/archive/Properties.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/publication/archive/Properties.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.shared.publication.archive
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
+import org.readium.r2.shared.JSONable
+import org.readium.r2.shared.extensions.optNullableBoolean
+import org.readium.r2.shared.extensions.optNullableLong
+import org.readium.r2.shared.extensions.optNullableString
+import org.readium.r2.shared.publication.Properties
+import org.readium.r2.shared.publication.encryption.Encryption
+import org.readium.r2.shared.publication.encryption.encryption
+import org.readium.r2.shared.util.logging.WarningLogger
+import org.readium.r2.shared.util.logging.log
+
+// Archive Link Properties Extension
+
+/**
+ * Holds information about how the resource is stored in the publication archive.
+ *
+ * @param entryLength The length of the entry stored in the archive. It might be a compressed length
+ *        if the entry is deflated.
+ * @param isEntryCompressed Indicates whether the entry was compressed before being stored in the
+ *        archive.
+ */
+@Parcelize
+data class ArchiveProperties(
+    val entryLength: Long,
+    val isEntryCompressed: Boolean
+) : JSONable, Parcelable {
+
+    override fun toJSON(): JSONObject = JSONObject().apply {
+        put("entryLength", entryLength)
+        put("isEntryCompressed", isEntryCompressed)
+    }
+
+    companion object {
+        fun fromJSON(json: JSONObject?, warnings: WarningLogger? = null): ArchiveProperties? {
+            json ?: return null
+
+            val entryLength = json.optNullableLong("entryLength")
+            val isEntryCompressed = json.optNullableBoolean("isEntryCompressed")
+            if (entryLength == null || isEntryCompressed == null) {
+                warnings?.log(ArchiveProperties::class.java, "[entryLength] and [isEntryCompressed] are required", json)
+                return null
+            }
+
+            return ArchiveProperties(entryLength = entryLength, isEntryCompressed = isEntryCompressed)
+        }
+
+    }
+}
+
+/**
+ * Provides information about how the resource is stored in the publication archive.
+ */
+val Properties.archive: ArchiveProperties?
+    get() = (this["archive"] as? Map<*, *>)
+        ?.let { ArchiveProperties.fromJSON(JSONObject(it)) }

--- a/r2-shared/src/main/java/org/readium/r2/shared/util/archive/Archive.kt
+++ b/r2-shared/src/main/java/org/readium/r2/shared/util/archive/Archive.kt
@@ -9,7 +9,6 @@
 
 package org.readium.r2.shared.util.archive
 
-import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.readium.r2.shared.extensions.tryOr
@@ -49,7 +48,10 @@ interface Archive : SuspendingCloseable {
      */
     interface Entry : SuspendingCloseable {
 
-        /** Absolute path to the entry in the archive. */
+        /**
+         * Absolute path to the entry in the archive.
+         * It MUST start with /.
+         */
         val path: String
 
         /**

--- a/r2-shared/src/test/java/org/readium/r2/shared/publication/archive/PropertiesTest.kt
+++ b/r2-shared/src/test/java/org/readium/r2/shared/publication/archive/PropertiesTest.kt
@@ -1,0 +1,71 @@
+package org.readium.r2.shared.publication.archive
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.readium.r2.shared.assertJSONEquals
+import org.readium.r2.shared.publication.Properties
+
+class PropertiesTest {
+
+    @Test
+    fun `get no archive`() {
+        assertNull(Properties().archive)
+    }
+
+    @Test
+    fun `get full archive`() {
+        assertEquals(
+            ArchiveProperties(entryLength = 8273, isEntryCompressed = true),
+            Properties(mapOf(
+                "archive" to mapOf(
+                    "entryLength" to 8273,
+                    "isEntryCompressed" to true
+                )
+            )).archive
+        )
+    }
+
+    @Test
+    fun `get invalid archive`() {
+        assertNull(
+            Properties(mapOf(
+                "archive" to mapOf(
+                    "foo" to "bar"
+                )
+            )).archive
+        )
+    }
+
+    @Test
+    fun `get incomplete archive`() {
+        assertNull(
+            Properties(mapOf(
+                "archive" to mapOf(
+                    "isEntryCompressed" to true
+                )
+            )).archive
+        )
+
+        assertNull(
+            Properties(mapOf(
+                "archive" to mapOf(
+                    "entryLength" to 8273
+                )
+            )).archive
+        )
+    }
+
+    @Test
+    fun `get archive JSON`() {
+        assertJSONEquals(
+            JSONObject(mapOf(
+                "entryLength" to 8273L,
+                "isEntryCompressed" to true
+            )),
+            ArchiveProperties(entryLength = 8273, isEntryCompressed = true).toJSON()
+        )
+    }
+
+}


### PR DESCRIPTION
### Added

* `Link` objects from archive-based publication assets (e.g. an EPUB/ZIP) have additional properties for entry metadata.
    ```json
    "properties" {
        "archive": {
            "entryLength": 8273,
            "isEntryCompressed": true
        }
    }
    ```


Port of https://github.com/readium/r2-shared-swift/pull/144